### PR TITLE
Fixes unsupported protocol scheme "localhost" in client example

### DIFF
--- a/example/cmd/client/main.go
+++ b/example/cmd/client/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	client := example.NewHaberdasherJSONClient("localhost:8080", &http.Client{})
+	client := example.NewHaberdasherJSONClient("http://localhost:8080", &http.Client{})
 
 	var (
 		hat *example.Hat


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Attempting to run the included server and client examples resulted the following on the client side:

```bash
➭ ./client
2018/01/17 11:31:20 twirp error internal: failed to do request: Post localhost:8080/twirp/twitch.twirp.example.Haberdasher/MakeHat: unsupported protocol scheme "localhost"
```

Adding `http://` to the scheme fixes the issue.

```bash
➭ ./client
size:12 color:"black" name:"top hat"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
