### PR TITLE
Adding a note on CoC and contribution licensing to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,16 @@ Twirp uses Github releases. To make a new release:
     "Draft a new release".
  4. Make sure to document changes, specially when upgrade instructions are
     needed.
+
+
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.
+
+
+## Licensing
+
+See the [LICENSE](https://github.com/twitchtv/twirp/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+
+We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION

*Description of changes:*

Adding content from the standard Amazon CONTRIBUTING file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
