### PR TITLE
Remove a stray golang.org/x/net/context import

### DIFF
--- a/internal/twirptest/service_test.go
+++ b/internal/twirptest/service_test.go
@@ -2,6 +2,7 @@ package twirptest
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -19,8 +20,6 @@ import (
 
 	"github.com/twitchtv/twirp"
 	"github.com/twitchtv/twirp/internal/descriptors"
-
-	"golang.org/x/net/context"
 )
 
 func TestServeJSON(t *testing.T) {


### PR DESCRIPTION
This is harmless, but it's an unecessary external dependency. We're for go1.7+, so we can safely require the standard library's context package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
