### PR TITLE
Make tests pass in go1.7

### DIFF
--- a/internal/gen/typemap/typemap_test.go
+++ b/internal/gen/typemap/typemap_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func loadTestPb(t *testing.T) []*descriptor.FileDescriptorProto {
-	t.Helper()
 	f, err := ioutil.ReadFile(filepath.Join("testdata", "fileset.pb"))
 	require.NoError(t, err, "unable to read testdata protobuf file")
 

--- a/internal/twirptest/service_test.go
+++ b/internal/twirptest/service_test.go
@@ -212,6 +212,7 @@ func recorderHooks() (*twirp.ServerHooks, *requestRecorder) {
 func TestHooks(t *testing.T) {
 	hooks, recorder := recorderHooks()
 	h := PickyHatmaker(1)
+
 	s := httptest.NewServer(NewHaberdasherServer(h, hooks))
 	defer s.Close()
 	client := NewHaberdasherProtobufClient(s.URL, http.DefaultClient)
@@ -310,6 +311,7 @@ func TestHooks(t *testing.T) {
 		rw := &reqRewriter{
 			base: http.DefaultTransport,
 			rewrite: func(r *http.Request) *http.Request {
+				r.ContentLength = 1
 				r.Body = ioutil.NopCloser(io.LimitReader(r.Body, 1))
 				return r
 			},


### PR DESCRIPTION
*Issue #, if available:*

Fixes #27.

*Description of changes:*

Two changes are needed here:

First, I just removed our call to `t.Helper`, which is a minor convenience thing but only available in go1.9.

Second, I had to explicitly set the `ContentLength` of a `*http.Request` in a test that sends a truncated request body. I don't really know what changed here between go1.7 and go1.9, but *something* did, and in go1.7 the `http.Client` refuse to send the request because its body doesn't provide the number of bytes that the ContenLength field expects. This fixes that with a hammer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
