### PR TITLE
update generated files

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -454,7 +454,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -595,7 +595,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/clientcompat/pycompat/clientcompat_pb2.py
+++ b/clientcompat/pycompat/clientcompat_pb2.py
@@ -84,7 +84,7 @@ _REQ = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -115,7 +115,7 @@ _RESP = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -146,21 +146,21 @@ _CLIENTCOMPATMESSAGE = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='method', full_name='twirp.clientcompat.ClientCompatMessage.method', index=1,
       number=2, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='request', full_name='twirp.clientcompat.ClientCompatMessage.request', index=2,
       number=3, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -302,7 +302,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -443,7 +443,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/example/service_pb2.py
+++ b/example/service_pb2.py
@@ -38,21 +38,21 @@ _HAT = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='color', full_name='twitch.twirp.example.Hat.color', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='name', full_name='twitch.twirp.example.Hat.name', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -83,7 +83,7 @@ _SIZE = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -304,7 +304,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -445,7 +445,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -303,7 +303,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -444,7 +444,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -305,7 +305,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -446,7 +446,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -304,7 +304,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -445,7 +445,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/multiple/multiple2_pb2.py
+++ b/internal/twirptest/multiple/multiple2_pb2.py
@@ -70,8 +70,8 @@ _SVC2 = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=62,
-  serialized_end=158,
+  serialized_start=80,
+  serialized_end=284,
   methods=[
   _descriptor.MethodDescriptor(
     name='Send',
@@ -80,6 +80,15 @@ _SVC2 = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_MSG2,
     output_type=_MSG2,
+    options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='SamePackageProtoImport',
+    full_name='twirp.internal.twirptest.multiple.Svc2.SamePackageProtoImport',
+    index=1,
+    containing_service=None,
+    input_type=multiple1__pb2._MSG1,
+    output_type=multiple1__pb2._MSG1,
     options=None,
   ),
 ])

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -300,7 +300,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -441,7 +441,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -302,7 +302,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -312,16 +312,6 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
-}
-
-// done returns ctx.Err() if ctx.Done() indicates that the context done
-func done(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		return nil
-	}
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -453,7 +443,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)
@@ -576,7 +566,7 @@ func doProtoRequest(ctx context.Context, client *http.Client, url string, in, ou
 		return clientError("failed to marshal proto request", err)
 	}
 	reqBody := bytes.NewBuffer(reqBodyBytes)
-	if err = done(ctx); err != nil {
+	if err = ctx.Err(); err != nil {
 		return clientError("aborted because context was done", err)
 	}
 
@@ -589,7 +579,7 @@ func doProtoRequest(ctx context.Context, client *http.Client, url string, in, ou
 		return clientError("failed to do request", err)
 	}
 	defer closebody(resp.Body)
-	if err = done(ctx); err != nil {
+	if err = ctx.Err(); err != nil {
 		return clientError("aborted because context was done", err)
 	}
 
@@ -601,7 +591,7 @@ func doProtoRequest(ctx context.Context, client *http.Client, url string, in, ou
 	if err != nil {
 		return clientError("failed to read response body", err)
 	}
-	if err = done(ctx); err != nil {
+	if err = ctx.Err(); err != nil {
 		return clientError("aborted because context was done", err)
 	}
 
@@ -619,7 +609,7 @@ func doJSONRequest(ctx context.Context, client *http.Client, url string, in, out
 	if err = marshaler.Marshal(reqBody, in); err != nil {
 		return clientError("failed to marshal json request", err)
 	}
-	if err = done(ctx); err != nil {
+	if err = ctx.Err(); err != nil {
 		return clientError("aborted because context was done", err)
 	}
 
@@ -632,7 +622,7 @@ func doJSONRequest(ctx context.Context, client *http.Client, url string, in, out
 		return clientError("failed to do request", err)
 	}
 	defer closebody(resp.Body)
-	if err = done(ctx); err != nil {
+	if err = ctx.Err(); err != nil {
 		return clientError("aborted because context was done", err)
 	}
 
@@ -644,7 +634,7 @@ func doJSONRequest(ctx context.Context, client *http.Client, url string, in, out
 	if err = unmarshaler.Unmarshal(resp.Body, out); err != nil {
 		return clientError("failed to unmarshal json response", err)
 	}
-	if err = done(ctx); err != nil {
+	if err = ctx.Err(); err != nil {
 		return clientError("aborted because context was done", err)
 	}
 	return nil

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer_pb2.py
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer_pb2.py
@@ -31,4 +31,28 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 DESCRIPTOR.has_options = True
 DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('Z\030no_package_name_importer'))
+
+_SVC2 = _descriptor.ServiceDescriptor(
+  name='Svc2',
+  full_name='Svc2',
+  file=DESCRIPTOR,
+  index=0,
+  options=None,
+  serialized_start=118,
+  serialized_end=146,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='Method',
+    full_name='Svc2.Method',
+    index=0,
+    containing_service=None,
+    input_type=github_dot_com_dot_twitchtv_dot_twirp_dot_internal_dot_twirptest_dot_no__package__name_dot_no__package__name__pb2._MSG,
+    output_type=github_dot_com_dot_twitchtv_dot_twirp_dot_internal_dot_twirptest_dot_no__package__name_dot_no__package__name__pb2._MSG,
+    options=None,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_SVC2)
+
+DESCRIPTOR.services_by_name['Svc2'] = _SVC2
+
 # @@protoc_insertion_point(module_scope)

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -303,7 +303,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -444,7 +444,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -302,7 +302,7 @@ type TwirpServer interface {
 	http.Handler
 	// ServiceDescriptor returns gzipped bytes describing the .proto file that
 	// this service was generated from. Once unzipped, the bytes can be
-	// unmarshaled as a
+	// unmarshalled as a
 	// github.com/golang/protobuf/protoc-gen-go/descriptor.FileDescriptorProto.
 	//
 	// The returned integer is the index of this particular service within that
@@ -443,7 +443,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 
 	if isHTTPRedirect(statusCode) {
 		// Unexpected redirect: it must be an error from an intermediary.
-		// Twirp clients dont't follow redirects automatically, Twirp only handles
+		// Twirp clients don't follow redirects automatically, Twirp only handles
 		// POST requests, redirects should only happen on GET and HEAD requests.
 		location := resp.Header.Get("Location")
 		msg := fmt.Sprintf("unexpected HTTP status code %d %q received, Location=%q", statusCode, statusText, location)

--- a/internal/twirptest/service_pb2.py
+++ b/internal/twirptest/service_pb2.py
@@ -38,21 +38,21 @@ _HAT = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='color', full_name='twirp.internal.twirptest.Hat.color', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='name', full_name='twirp.internal.twirptest.Hat.name', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -83,7 +83,7 @@ _SIZE = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],


### PR DESCRIPTION
Fixes #18.

This PR is a fresh run of `make`, with `protoc --version` `libprotoc 3.5.1`.  The Python changes are from the protoc upgrade and may not be desired.  The Go changes are from spelling fixes in Twirp's generator and should be synced up. Maybe CI could run `make` and check for changes to prevent drift in the future.

Happy to redo this with protoc 3.1 or 3.3 as required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
