### PR TITLE
go-client: precompute service url strings

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -43,30 +43,32 @@ type CompatService interface {
 // =============================
 
 type compatServiceProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [2]string
 }
 
 // NewCompatServiceProtobufClient creates a Protobuf client that implements the CompatService interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewCompatServiceProtobufClient(addr string, client *http.Client) CompatService {
+	prefix := urlBase(addr) + CompatServicePathPrefix
 	return &compatServiceProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [2]string{
+			prefix + "Method",
+			prefix + "NoopMethod",
+		},
 	}
 }
 
 func (c *compatServiceProtobufClient) Method(ctx context.Context, in *Req) (*Resp, error) {
-	url := c.urlBase + CompatServicePathPrefix + "Method"
 	out := new(Resp)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
 func (c *compatServiceProtobufClient) NoopMethod(ctx context.Context, in *Empty) (*Empty, error) {
-	url := c.urlBase + CompatServicePathPrefix + "NoopMethod"
 	out := new(Empty)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[1], in, out)
 	return out, err
 }
 
@@ -75,30 +77,32 @@ func (c *compatServiceProtobufClient) NoopMethod(ctx context.Context, in *Empty)
 // =========================
 
 type compatServiceJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [2]string
 }
 
 // NewCompatServiceJSONClient creates a JSON client that implements the CompatService interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewCompatServiceJSONClient(addr string, client *http.Client) CompatService {
+	prefix := urlBase(addr) + CompatServicePathPrefix
 	return &compatServiceJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [2]string{
+			prefix + "Method",
+			prefix + "NoopMethod",
+		},
 	}
 }
 
 func (c *compatServiceJSONClient) Method(ctx context.Context, in *Req) (*Resp, error) {
-	url := c.urlBase + CompatServicePathPrefix + "Method"
 	out := new(Resp)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
 func (c *compatServiceJSONClient) NoopMethod(ctx context.Context, in *Empty) (*Empty, error) {
-	url := c.urlBase + CompatServicePathPrefix + "NoopMethod"
 	out := new(Empty)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[1], in, out)
 	return out, err
 }
 

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -43,23 +43,25 @@ type Haberdasher interface {
 // ===========================
 
 type haberdasherProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewHaberdasherProtobufClient(addr string, client *http.Client) Haberdasher {
+	prefix := urlBase(addr) + HaberdasherPathPrefix
 	return &haberdasherProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "MakeHat",
+		},
 	}
 }
 
 func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
-	url := c.urlBase + HaberdasherPathPrefix + "MakeHat"
 	out := new(Hat)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -68,23 +70,25 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 // =======================
 
 type haberdasherJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewHaberdasherJSONClient(addr string, client *http.Client) Haberdasher {
+	prefix := urlBase(addr) + HaberdasherPathPrefix
 	return &haberdasherJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "MakeHat",
+		},
 	}
 }
 
 func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
-	url := c.urlBase + HaberdasherPathPrefix + "MakeHat"
 	out := new(Hat)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -45,23 +45,25 @@ type Svc interface {
 // ===================
 
 type svcProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvcProtobufClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -70,23 +72,25 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 // ===============
 
 type svcJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvcJSONClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -44,23 +44,25 @@ type Svc interface {
 // ===================
 
 type svcProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvcProtobufClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -69,23 +71,25 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 // ===============
 
 type svcJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvcJSONClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -46,23 +46,25 @@ type Svc2 interface {
 // ====================
 
 type svc2ProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvc2ProtobufClient creates a Protobuf client that implements the Svc2 interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvc2ProtobufClient(addr string, client *http.Client) Svc2 {
+	prefix := urlBase(addr) + Svc2PathPrefix
 	return &svc2ProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svc2ProtobufClient) Send(ctx context.Context, in *twirp_internal_twirptest_importable.Msg) (*twirp_internal_twirptest_importable.Msg, error) {
-	url := c.urlBase + Svc2PathPrefix + "Send"
 	out := new(twirp_internal_twirptest_importable.Msg)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -71,23 +73,25 @@ func (c *svc2ProtobufClient) Send(ctx context.Context, in *twirp_internal_twirpt
 // ================
 
 type svc2JSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvc2JSONClient creates a JSON client that implements the Svc2 interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvc2JSONClient(addr string, client *http.Client) Svc2 {
+	prefix := urlBase(addr) + Svc2PathPrefix
 	return &svc2JSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svc2JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_importable.Msg) (*twirp_internal_twirptest_importable.Msg, error) {
-	url := c.urlBase + Svc2PathPrefix + "Send"
 	out := new(twirp_internal_twirptest_importable.Msg)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -45,23 +45,25 @@ type Svc1 interface {
 // ====================
 
 type svc1ProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvc1ProtobufClient creates a Protobuf client that implements the Svc1 interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvc1ProtobufClient(addr string, client *http.Client) Svc1 {
+	prefix := urlBase(addr) + Svc1PathPrefix
 	return &svc1ProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svc1ProtobufClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
-	url := c.urlBase + Svc1PathPrefix + "Send"
 	out := new(Msg1)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -70,23 +72,25 @@ func (c *svc1ProtobufClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) 
 // ================
 
 type svc1JSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvc1JSONClient creates a JSON client that implements the Svc1 interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvc1JSONClient(addr string, client *http.Client) Svc1 {
+	prefix := urlBase(addr) + Svc1PathPrefix
 	return &svc1JSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svc1JSONClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
-	url := c.urlBase + Svc1PathPrefix + "Send"
 	out := new(Msg1)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -30,30 +30,32 @@ type Svc2 interface {
 // ====================
 
 type svc2ProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [2]string
 }
 
 // NewSvc2ProtobufClient creates a Protobuf client that implements the Svc2 interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvc2ProtobufClient(addr string, client *http.Client) Svc2 {
+	prefix := urlBase(addr) + Svc2PathPrefix
 	return &svc2ProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [2]string{
+			prefix + "Send",
+			prefix + "SamePackageProtoImport",
+		},
 	}
 }
 
 func (c *svc2ProtobufClient) Send(ctx context.Context, in *Msg2) (*Msg2, error) {
-	url := c.urlBase + Svc2PathPrefix + "Send"
 	out := new(Msg2)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
 func (c *svc2ProtobufClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (*Msg1, error) {
-	url := c.urlBase + Svc2PathPrefix + "SamePackageProtoImport"
 	out := new(Msg1)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[1], in, out)
 	return out, err
 }
 
@@ -62,30 +64,32 @@ func (c *svc2ProtobufClient) SamePackageProtoImport(ctx context.Context, in *Msg
 // ================
 
 type svc2JSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [2]string
 }
 
 // NewSvc2JSONClient creates a JSON client that implements the Svc2 interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvc2JSONClient(addr string, client *http.Client) Svc2 {
+	prefix := urlBase(addr) + Svc2PathPrefix
 	return &svc2JSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [2]string{
+			prefix + "Send",
+			prefix + "SamePackageProtoImport",
+		},
 	}
 }
 
 func (c *svc2JSONClient) Send(ctx context.Context, in *Msg2) (*Msg2, error) {
-	url := c.urlBase + Svc2PathPrefix + "Send"
 	out := new(Msg2)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
 func (c *svc2JSONClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (*Msg1, error) {
-	url := c.urlBase + Svc2PathPrefix + "SamePackageProtoImport"
 	out := new(Msg1)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[1], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -41,23 +41,25 @@ type Svc interface {
 // ===================
 
 type svcProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvcProtobufClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -66,23 +68,25 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 // ===============
 
 type svcJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvcJSONClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -43,23 +43,25 @@ type Svc2 interface {
 // ====================
 
 type svc2ProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvc2ProtobufClient creates a Protobuf client that implements the Svc2 interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvc2ProtobufClient(addr string, client *http.Client) Svc2 {
+	prefix := urlBase(addr) + Svc2PathPrefix
 	return &svc2ProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Method",
+		},
 	}
 }
 
 func (c *svc2ProtobufClient) Method(ctx context.Context, in *no_package_name.Msg) (*no_package_name.Msg, error) {
-	url := c.urlBase + Svc2PathPrefix + "Method"
 	out := new(no_package_name.Msg)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -68,23 +70,25 @@ func (c *svc2ProtobufClient) Method(ctx context.Context, in *no_package_name.Msg
 // ================
 
 type svc2JSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvc2JSONClient creates a JSON client that implements the Svc2 interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvc2JSONClient(addr string, client *http.Client) Svc2 {
+	prefix := urlBase(addr) + Svc2PathPrefix
 	return &svc2JSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Method",
+		},
 	}
 }
 
 func (c *svc2JSONClient) Method(ctx context.Context, in *no_package_name.Msg) (*no_package_name.Msg, error) {
-	url := c.urlBase + Svc2PathPrefix + "Method"
 	out := new(no_package_name.Msg)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -44,23 +44,25 @@ type Svc interface {
 // ===================
 
 type svcProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewSvcProtobufClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -69,23 +71,25 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 // ===============
 
 type svcJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewSvcJSONClient(addr string, client *http.Client) Svc {
+	prefix := urlBase(addr) + SvcPathPrefix
 	return &svcJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "Send",
+		},
 	}
 }
 
 func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
-	url := c.urlBase + SvcPathPrefix + "Send"
 	out := new(Msg)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -43,23 +43,25 @@ type Haberdasher interface {
 // ===========================
 
 type haberdasherProtobufClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
 // It communicates using protobuf messages and can be configured with a custom http.Client.
 func NewHaberdasherProtobufClient(addr string, client *http.Client) Haberdasher {
+	prefix := urlBase(addr) + HaberdasherPathPrefix
 	return &haberdasherProtobufClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "MakeHat",
+		},
 	}
 }
 
 func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
-	url := c.urlBase + HaberdasherPathPrefix + "MakeHat"
 	out := new(Hat)
-	err := doProtoRequest(ctx, c.client, url, in, out)
+	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -68,23 +70,25 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 // =======================
 
 type haberdasherJSONClient struct {
-	urlBase string
-	client  *http.Client
+	client *http.Client
+	urls   [1]string
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
 // It communicates using JSON requests and responses instead of protobuf messages.
 func NewHaberdasherJSONClient(addr string, client *http.Client) Haberdasher {
+	prefix := urlBase(addr) + HaberdasherPathPrefix
 	return &haberdasherJSONClient{
-		urlBase: urlBase(addr),
-		client:  withoutRedirects(client),
+		client: withoutRedirects(client),
+		urls: [1]string{
+			prefix + "MakeHat",
+		},
 	}
 }
 
 func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
-	url := c.urlBase + HaberdasherPathPrefix + "MakeHat"
 	out := new(Hat)
-	err := doJSONRequest(ctx, c.client, url, in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 


### PR DESCRIPTION
This PR proposes a small change to generated Go clients. By replacing the `urlBase` field with a pre-computed array of service `urls`, service methods can do an array look-up instead of repetitive string concatenation, at the cost of more initialization in the constructor functions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
