### PR TITLE
go-client: reduce repeated generator code

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -48,7 +48,7 @@ type compatServiceProtobufClient struct {
 }
 
 // NewCompatServiceProtobufClient creates a Protobuf client that implements the CompatService interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewCompatServiceProtobufClient(addr string, client HTTPClient) CompatService {
 	prefix := urlBase(addr) + CompatServicePathPrefix
 	urls := [2]string{
@@ -69,13 +69,13 @@ func NewCompatServiceProtobufClient(addr string, client HTTPClient) CompatServic
 
 func (c *compatServiceProtobufClient) Method(ctx context.Context, in *Req) (*Resp, error) {
 	out := new(Resp)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
 func (c *compatServiceProtobufClient) NoopMethod(ctx context.Context, in *Empty) (*Empty, error) {
 	out := new(Empty)
-	err := doProtoRequest(ctx, c.client, c.urls[1], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[1], in, out)
 	return out, err
 }
 
@@ -89,7 +89,7 @@ type compatServiceJSONClient struct {
 }
 
 // NewCompatServiceJSONClient creates a JSON client that implements the CompatService interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewCompatServiceJSONClient(addr string, client HTTPClient) CompatService {
 	prefix := urlBase(addr) + CompatServicePathPrefix
 	urls := [2]string{
@@ -740,8 +740,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -48,7 +48,7 @@ type haberdasherProtobufClient struct {
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewHaberdasherProtobufClient(addr string, client HTTPClient) Haberdasher {
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
@@ -68,7 +68,7 @@ func NewHaberdasherProtobufClient(addr string, client HTTPClient) Haberdasher {
 
 func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
 	out := new(Hat)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -82,7 +82,7 @@ type haberdasherJSONClient struct {
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewHaberdasherJSONClient(addr string, client HTTPClient) Haberdasher {
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
@@ -588,8 +588,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -50,7 +50,7 @@ type svcProtobufClient struct {
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -70,7 +70,7 @@ func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -84,7 +84,7 @@ type svcJSONClient struct {
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvcJSONClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -590,8 +590,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -49,7 +49,7 @@ type svcProtobufClient struct {
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -69,7 +69,7 @@ func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -83,7 +83,7 @@ type svcJSONClient struct {
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvcJSONClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -589,8 +589,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -51,7 +51,7 @@ type svc2ProtobufClient struct {
 }
 
 // NewSvc2ProtobufClient creates a Protobuf client that implements the Svc2 interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvc2ProtobufClient(addr string, client HTTPClient) Svc2 {
 	prefix := urlBase(addr) + Svc2PathPrefix
 	urls := [1]string{
@@ -71,7 +71,7 @@ func NewSvc2ProtobufClient(addr string, client HTTPClient) Svc2 {
 
 func (c *svc2ProtobufClient) Send(ctx context.Context, in *twirp_internal_twirptest_importable.Msg) (*twirp_internal_twirptest_importable.Msg, error) {
 	out := new(twirp_internal_twirptest_importable.Msg)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -85,7 +85,7 @@ type svc2JSONClient struct {
 }
 
 // NewSvc2JSONClient creates a JSON client that implements the Svc2 interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvc2JSONClient(addr string, client HTTPClient) Svc2 {
 	prefix := urlBase(addr) + Svc2PathPrefix
 	urls := [1]string{
@@ -591,8 +591,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -50,7 +50,7 @@ type svc1ProtobufClient struct {
 }
 
 // NewSvc1ProtobufClient creates a Protobuf client that implements the Svc1 interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvc1ProtobufClient(addr string, client HTTPClient) Svc1 {
 	prefix := urlBase(addr) + Svc1PathPrefix
 	urls := [1]string{
@@ -70,7 +70,7 @@ func NewSvc1ProtobufClient(addr string, client HTTPClient) Svc1 {
 
 func (c *svc1ProtobufClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
 	out := new(Msg1)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -84,7 +84,7 @@ type svc1JSONClient struct {
 }
 
 // NewSvc1JSONClient creates a JSON client that implements the Svc1 interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvc1JSONClient(addr string, client HTTPClient) Svc1 {
 	prefix := urlBase(addr) + Svc1PathPrefix
 	urls := [1]string{
@@ -590,8 +590,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -35,7 +35,7 @@ type svc2ProtobufClient struct {
 }
 
 // NewSvc2ProtobufClient creates a Protobuf client that implements the Svc2 interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvc2ProtobufClient(addr string, client HTTPClient) Svc2 {
 	prefix := urlBase(addr) + Svc2PathPrefix
 	urls := [2]string{
@@ -56,13 +56,13 @@ func NewSvc2ProtobufClient(addr string, client HTTPClient) Svc2 {
 
 func (c *svc2ProtobufClient) Send(ctx context.Context, in *Msg2) (*Msg2, error) {
 	out := new(Msg2)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
 func (c *svc2ProtobufClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (*Msg1, error) {
 	out := new(Msg1)
-	err := doProtoRequest(ctx, c.client, c.urls[1], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[1], in, out)
 	return out, err
 }
 
@@ -76,7 +76,7 @@ type svc2JSONClient struct {
 }
 
 // NewSvc2JSONClient creates a JSON client that implements the Svc2 interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvc2JSONClient(addr string, client HTTPClient) Svc2 {
 	prefix := urlBase(addr) + Svc2PathPrefix
 	urls := [2]string{

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -46,7 +46,7 @@ type svcProtobufClient struct {
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -66,7 +66,7 @@ func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -80,7 +80,7 @@ type svcJSONClient struct {
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvcJSONClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -586,8 +586,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -48,7 +48,7 @@ type svc2ProtobufClient struct {
 }
 
 // NewSvc2ProtobufClient creates a Protobuf client that implements the Svc2 interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvc2ProtobufClient(addr string, client HTTPClient) Svc2 {
 	prefix := urlBase(addr) + Svc2PathPrefix
 	urls := [1]string{
@@ -68,7 +68,7 @@ func NewSvc2ProtobufClient(addr string, client HTTPClient) Svc2 {
 
 func (c *svc2ProtobufClient) Method(ctx context.Context, in *no_package_name.Msg) (*no_package_name.Msg, error) {
 	out := new(no_package_name.Msg)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -82,7 +82,7 @@ type svc2JSONClient struct {
 }
 
 // NewSvc2JSONClient creates a JSON client that implements the Svc2 interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvc2JSONClient(addr string, client HTTPClient) Svc2 {
 	prefix := urlBase(addr) + Svc2PathPrefix
 	urls := [1]string{
@@ -588,8 +588,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -49,7 +49,7 @@ type svcProtobufClient struct {
 }
 
 // NewSvcProtobufClient creates a Protobuf client that implements the Svc interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -69,7 +69,7 @@ func NewSvcProtobufClient(addr string, client HTTPClient) Svc {
 
 func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	out := new(Msg)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -83,7 +83,7 @@ type svcJSONClient struct {
 }
 
 // NewSvcJSONClient creates a JSON client that implements the Svc interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewSvcJSONClient(addr string, client HTTPClient) Svc {
 	prefix := urlBase(addr) + SvcPathPrefix
 	urls := [1]string{
@@ -589,8 +589,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -48,7 +48,7 @@ type haberdasherProtobufClient struct {
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
-// It communicates using protobuf messages and can be configured with a custom http.Client.
+// It communicates using Protobuf and can be configured with a custom HTTPClient.
 func NewHaberdasherProtobufClient(addr string, client HTTPClient) Haberdasher {
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
@@ -68,7 +68,7 @@ func NewHaberdasherProtobufClient(addr string, client HTTPClient) Haberdasher {
 
 func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
 	out := new(Hat)
-	err := doProtoRequest(ctx, c.client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	return out, err
 }
 
@@ -82,7 +82,7 @@ type haberdasherJSONClient struct {
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
-// It communicates using JSON requests and responses instead of protobuf messages.
+// It communicates using JSON and can be configured with a custom HTTPClient.
 func NewHaberdasherJSONClient(addr string, client HTTPClient) Haberdasher {
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
@@ -588,8 +588,8 @@ func withoutRedirects(in *http.Client) *http.Client {
 	return &copy
 }
 
-// doProtoRequest is common code to make a request to the remote twirp service.
-func doProtoRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
+// doProtobufRequest is common code to make a request to the remote twirp service.
+func doProtobufRequest(ctx context.Context, client HTTPClient, url string, in, out proto.Message) error {
 	var err error
 	reqBodyBytes, err := proto.Marshal(in)
 	if err != nil {


### PR DESCRIPTION
This PR proposes replacing the `generator.go` methods `generateProtobufClient` and `generateJSONClient` (which are nearly identical) with a parameterized `generateClient`.  The generated code remains functionally identical, but I aligned a few things (comments, `doProtoRequest()`->`doProtobufRequest()`) to keep the code simpler.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
