### PR TITLE
List third party generators on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ You will also need:
 ### Documentation
 Thorough documentation is [on the wiki](https://github.com/twitchtv/twirp/wiki).
 
+### Implementations in other languages
+
+This repo only has the official generators, which write out Go and Python code.
+For other languages, there are third-party generators available:
+
+|    Language    | Repository |
+|----------------|------------|
+| **JavaScript** | [github.com/thechriswalker/protoc-gen-twirp_js](https://github.com/thechriswalker/protoc-gen-twirp_js)
+| **JavaScript** | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_jsbrowser](https://github.com/Xe/twirp-codegens)
+| **Lua**        | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_eclier](https://github.com/Xe/twirp-codegens)
+| **Ruby**       | [github.com/gaffneyc/protoc-gen-twirp_ruby](https://github.com/gaffneyc/protoc-gen-twirp_ruby)
+| **Swagger**    | [github.com/elliots/protoc-gen-twirp_swagger](https://github.com/elliots/protoc-gen-twirp_swagger)
+
+This list isn't an endorsement, it's just a convenience to help you find stuff
+for your language.
+
 ### Support and Community
 We have a channel on the Gophers slack, [#twirp](https://gophers.slack.com/messages/twirp),
 which is the best place to get quick answers to your questions. You can join the

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For other languages, there are third-party generators available:
 
 |    Language    | Repository |
 |----------------|------------|
+| **Java**       | [github.com/fajran/protoc-gen-twirp_java_jaxrs](https://github.com/fajran/protoc-gen-twirp_java_jaxrs)
 | **JavaScript** | [github.com/thechriswalker/protoc-gen-twirp_js](https://github.com/thechriswalker/protoc-gen-twirp_js)
 | **JavaScript** | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_jsbrowser](https://github.com/Xe/twirp-codegens)
 | **Lua**        | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_eclier](https://github.com/Xe/twirp-codegens)


### PR DESCRIPTION
As laid out in #61, I'd like to highlight these community-written generators.

I'd like an explicit okay from each person I'm linking to:
- [x] @elliots
- [x] @fajran
- [x] @gaffneyc
- [x] @thechriswalker
- [x] @Xe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
