### PR TITLE
protoc: update to 3.5.1 everywhere; verify from Makefile

### DIFF
--- a/install_proto.bash
+++ b/install_proto.bash
@@ -17,7 +17,12 @@ which protoc
 PROTOC_EXISTS=$?
 if [ $PROTOC_EXISTS -eq 0 ]; then
     echo "Protoc already installed"
-    exit 0
+	PROTOC_VERSION=`protoc --version`
+	if [ "$PROTOC_VERSION" == "libprotoc 3.5.1" ]; then
+		exit 0
+	fi
+	echo "libprotoc 3.5.1 required, but found: $PROTOC_VERSION"
+	exit 1
 fi
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -25,8 +30,8 @@ if [ "$(uname)" == "Darwin" ]; then
 elif [ `whoami` == "root" ]; then
     mkdir -p /usr/local/src/protoc
     pushd /usr/local/src/protoc
-    wget https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -O /usr/local/src/protoc-3.1.0-linux-x86_64.zip
-    unzip -x ../protoc-3.1.0-linux-x86_64.zip
+    wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip -O /usr/local/src/protoc-3.5.1-linux-x86_64.zip
+    unzip -x ../protoc-3.5.1-linux-x86_64.zip
     if [ ! -e /usr/local/bin/protoc ]; then
         ln -s `pwd`/bin/protoc /usr/local/bin/protoc
     fi
@@ -36,8 +41,8 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     sudo chmod a+w /usr/local/src
     mkdir -p /usr/local/src/protoc
     pushd /usr/local/src/protoc
-    wget https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -O /usr/local/src/protoc-3.1.0-linux-x86_64.zip
-    unzip -x ../protoc-3.1.0-linux-x86_64.zip
+    wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip -O /usr/local/src/protoc-3.5.1-linux-x86_64.zip
+    unzip -x ../protoc-3.5.1-linux-x86_64.zip
     if [ ! -e /usr/local/bin/protoc ]; then
         sudo ln -s `pwd`/bin/protoc /usr/local/bin/protoc
     fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2017.4.17
 chardet==3.0.4
 idna==2.5
-protobuf==3.3.0
+protobuf==3.5.1
 requests==2.17.3
 six==1.10.0
 urllib3==1.21.1


### PR DESCRIPTION
#18 

This PR updates some protoc 3.1.0 and 3.3.0 references to 3.5.1, and extends Makefile/install_proto verification to that specific version as well. Here is example output from running `make` with the wrong version installed:
```sh
./install_proto.bash
/usr/local/bin/protoc
Protoc already installed
libprotoc 3.5.1 required, but found: libprotoc 3.3.0
Makefile:29: recipe for target 'setup' failed
make: *** [setup] Error 1
```
The happy path output remains the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
