### PR TITLE
Set Accept header in generated client requests

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -603,6 +603,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/context.go
+++ b/context.go
@@ -67,6 +67,9 @@ func StatusCode(ctx context.Context) (string, bool) {
 // WithHTTPRequestHeaders returns an error if the provided http.Header
 // would overwrite a header that is needed by Twirp, like "Content-Type".
 func WithHTTPRequestHeaders(ctx context.Context, h http.Header) (context.Context, error) {
+	if _, ok := h["Accept"]; ok {
+		return nil, errors.New("provided header cannot set Accept")
+	}
 	if _, ok := h["Content-Type"]; ok {
 		return nil, errors.New("provided header cannot set Content-Type")
 	}

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -440,6 +440,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -442,6 +442,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -441,6 +441,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -443,6 +443,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -442,6 +442,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -438,6 +438,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -440,6 +440,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -441,6 +441,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -440,6 +440,7 @@ func newRequest(ctx context.Context, url string, reqBody io.Reader, contentType 
 	if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {
 		req.Header = customHeader
 	}
+	req.Header.Set("Accept", contentType)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Twirp-Version", "v5.2.0")
 	return req, nil

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -418,6 +418,7 @@ func (t *twirp) generateUtils() {
 	t.P(`  if customHeader := getCustomHTTPReqHeaders(ctx); customHeader != nil {`)
 	t.P(`    req.Header = customHeader`)
 	t.P(`  }`)
+	t.P(`  req.Header.Set("Accept", contentType)`)
 	t.P(`  req.Header.Set("Content-Type", contentType)`)
 	t.P(`  req.Header.Set("Twirp-Version", "`, gen.Version, `")`)
 	t.P(`  return req, nil`)


### PR DESCRIPTION
fixes #81

Added Accept header to JSON and protobuf clients and ran make.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
