### PR TITLE
fix typo in client example code

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -189,9 +189,9 @@ import (
 )
 
 func main() {
-    client := haberdasher.NewHaberdasherProtobufClient("http://localhost:8000", &http.Client{})
+    client := haberdasher.NewHaberdasherProtobufClient("http://localhost:8080", &http.Client{})
 
-    hat, err := client.MakeHat(context.Background(), &example.Size{Inches: 12})
+    hat, err := client.MakeHat(context.Background(), &haberdasher.Size{Inches: 12})
     if err != nil {
         fmt.Printf("oh no: %v", err)
         os.Exit(1)

--- a/docs/example.md
+++ b/docs/example.md
@@ -178,7 +178,7 @@ To use the `Haberdasher` service from another Go project, just import the
 auto-generated client and then use it. You might do this, in `cmd/client/main.go`:
 
 ```go
-pacage main
+package main
 
 import (
     "context"


### PR DESCRIPTION
Fixes incorrect spelling of `package` in the client code example, as well as a couple of little client fixes.