### PR TITLE
Make Python TwirpExceptions better behaved.

### DIFF
--- a/clientcompat/pycompat/clientcompat_pb2_twirp.py
+++ b/clientcompat/pycompat/clientcompat_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/example/service_pb2_twirp.py
+++ b/example/service_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/importable/importable_pb2_twirp.py
+++ b/internal/twirptest/importable/importable_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/importer/importer_pb2_twirp.py
+++ b/internal/twirptest/importer/importer_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/multiple/multiple1_pb2_twirp.py
+++ b/internal/twirptest/multiple/multiple1_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/multiple/multiple2_pb2_twirp.py
+++ b/internal/twirptest/multiple/multiple2_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/no_package_name/no_package_name_pb2_twirp.py
+++ b/internal/twirptest/no_package_name/no_package_name_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer_pb2_twirp.py
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/proto/proto_pb2_twirp.py
+++ b/internal/twirptest/proto/proto_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/internal/twirptest/service_pb2_twirp.py
+++ b/internal/twirptest/service_pb2_twirp.py
@@ -18,6 +18,7 @@ class TwirpException(httplib.HTTPException):
         self.code = code
         self.message = message
         self.meta = meta
+        super(TwirpException, self).__init__(message)
 
     @classmethod
     def from_http_err(cls, err):

--- a/protoc-gen-twirp_python/main.go
+++ b/protoc-gen-twirp_python/main.go
@@ -87,6 +87,7 @@ func (g *generator) generateFile(file *descriptor.FileDescriptorProto) *plugin.C
 	g.P(`        self.code = code`)
 	g.P(`        self.message = message`)
 	g.P(`        self.meta = meta`)
+	g.P(`        super(TwirpException, self).__init__(message)`)
 	g.P()
 	g.P(`    @classmethod`)
 	g.P(`    def from_http_err(cls, err):`)


### PR DESCRIPTION
- Use standard Exception super().\_\_init\_\_() to give TwirpExceptions a
message so that they print out more useful information in a backtrace.
- Update all generated python files appropriately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
