### PR TITLE
Add reference to Twirp Ruby services

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For other languages, there are third-party generators available:
 | **Java**       |    ✓    |         | [github.com/fajran/protoc-gen-twirp_java_jaxrs](https://github.com/fajran/protoc-gen-twirp_java_jaxrs)
 | **JavaScript** |    ✓    |         | [github.com/thechriswalker/protoc-gen-twirp_js](https://github.com/thechriswalker/protoc-gen-twirp_js)
 | **JavaScript** |    ✓    |         | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_jsbrowser](https://github.com/Xe/twirp-codegens)
+| **Ruby**       |         |    ✓    | [github.com/cyrusaf/ruby-twirp](https://github.com/cyrusaf/ruby-twirp)
 | **Ruby**       |    ✓    |         | [github.com/gaffneyc/protoc-gen-twirp_ruby](https://github.com/gaffneyc/protoc-gen-twirp_ruby)
 | **Rust**       |    ✓    |    ✓    | [github.com/cretz/prost-twirp](https://github.com/cretz/prost-twirp)
 | **Swagger**    |    ✓    |    ✓    | [github.com/elliots/protoc-gen-twirp_swagger](https://github.com/elliots/protoc-gen-twirp_swagger)


### PR DESCRIPTION
@cyrusaf and me have the Ruby `twirp` gem up and running, currently at version `v0.1.0` (feature complete for the service, but not tested in production yet).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Twirp::Error

The package `twirp/error` defines the `Twirp::Error` class. This will be used both by services and clients.

### Twirp::Service

The package `twirp/service` allows to use the service DSL to define services from existing Protobuf message classes:

```ruby
class Haberdasher < Twirp::Service
  rpc :MakeHat, Size, Hat, :handler_method => :make_hat
end
```

The service is implemented with a handler, for example:

```ruby
class HaberdasherHandler
  def make_hat(size)
    {size: size, name: "Hat"}
  end
end
```

And then mounted as a Rack app, with optional hooks, for example:

```ruby
handler = HaberdasherHandler.new
service = Haberdasher.new(handler)
service.before do |rack_env, env|
  env[:user_id] = authenticate(rack_env)
end

Rack::Handler::WEBrick.run service
```

### Twirp::Client

Clients are not implemented yet, but they are right next in the roadmap.

The idea is to make a dynamic JSON client that can be used without proto files for convenience:

```ruby
jsonClient = Twirp::JSONClient.new(base_url: "http://localhost:8081", package: 'foo.bar', service: "Haberdasher")
resp, twerr = jsonClient.rpc(:MakeHat, inches: 5) # resp is a plain Hash
```

But also a Proto client that is generated from the proto file, that responds with the message classes defined by the protoc compiler:

```ruby
protoClient = Haberdasher.ProtoClient("http://localhost:8081")
resp, twerr = protoClient.make_hat(inches: 5) # resp is a Hat
```

### Code Generation

The repo also includes the protoc plugin `protoc-gen-twirp_ruby`:

```sh
protoc --proto_path=. ./haberdasher.proto --ruby_out=gen --twirp_ruby_out=gen
```

For now it only generates service code, but soon will also generate the proto client for the service.


