### PR TITLE
Remove /twirp prefix from routes

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -157,7 +157,7 @@ func (s *compatServiceServer) writeError(ctx context.Context, resp http.Response
 // CompatServicePathPrefix is used for all URL paths on a twirp CompatService server.
 // Requests are always: POST CompatServicePathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const CompatServicePathPrefix = "/twirp/twirp.clientcompat.CompatService/"
+const CompatServicePathPrefix = "/twirp.clientcompat.CompatService/"
 
 func (s *compatServiceServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -180,10 +180,10 @@ func (s *compatServiceServer) ServeHTTP(resp http.ResponseWriter, req *http.Requ
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.clientcompat.CompatService/Method":
+	case "/twirp.clientcompat.CompatService/Method":
 		s.serveMethod(ctx, resp, req)
 		return
-	case "/twirp/twirp.clientcompat.CompatService/NoopMethod":
+	case "/twirp.clientcompat.CompatService/NoopMethod":
 		s.serveNoopMethod(ctx, resp, req)
 		return
 	default:

--- a/clientcompat/pycompat/clientcompat_pb2_twirp.py
+++ b/clientcompat/pycompat/clientcompat_pb2_twirp.py
@@ -49,7 +49,7 @@ class CompatServiceClient(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -137,7 +137,7 @@ func (s *haberdasherServer) writeError(ctx context.Context, resp http.ResponseWr
 // HaberdasherPathPrefix is used for all URL paths on a twirp Haberdasher server.
 // Requests are always: POST HaberdasherPathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const HaberdasherPathPrefix = "/twirp/twitch.twirp.example.Haberdasher/"
+const HaberdasherPathPrefix = "/twitch.twirp.example.Haberdasher/"
 
 func (s *haberdasherServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -160,7 +160,7 @@ func (s *haberdasherServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twitch.twirp.example.Haberdasher/MakeHat":
+	case "/twitch.twirp.example.Haberdasher/MakeHat":
 		s.serveMakeHat(ctx, resp, req)
 		return
 	default:

--- a/example/service_pb2_twirp.py
+++ b/example/service_pb2_twirp.py
@@ -53,7 +53,7 @@ class HaberdasherClient(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -139,7 +139,7 @@ func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, er
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
 // Requests are always: POST SvcPathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const SvcPathPrefix = "/twirp/twirp.internal.twirptest.gogo_compat.Svc/"
+const SvcPathPrefix = "/twirp.internal.twirptest.gogo_compat.Svc/"
 
 func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -162,7 +162,7 @@ func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.gogo_compat.Svc/Send":
+	case "/twirp.internal.twirptest.gogo_compat.Svc/Send":
 		s.serveSend(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -138,7 +138,7 @@ func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, er
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
 // Requests are always: POST SvcPathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const SvcPathPrefix = "/twirp/twirp.internal.twirptest.importable.Svc/"
+const SvcPathPrefix = "/twirp.internal.twirptest.importable.Svc/"
 
 func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -161,7 +161,7 @@ func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.importable.Svc/Send":
+	case "/twirp.internal.twirptest.importable.Svc/Send":
 		s.serveSend(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/importable/importable_pb2_twirp.py
+++ b/internal/twirptest/importable/importable_pb2_twirp.py
@@ -49,7 +49,7 @@ class SvcClient(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -140,7 +140,7 @@ func (s *svc2Server) writeError(ctx context.Context, resp http.ResponseWriter, e
 // Svc2PathPrefix is used for all URL paths on a twirp Svc2 server.
 // Requests are always: POST Svc2PathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const Svc2PathPrefix = "/twirp/twirp.internal.twirptest.importer.Svc2/"
+const Svc2PathPrefix = "/twirp.internal.twirptest.importer.Svc2/"
 
 func (s *svc2Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -163,7 +163,7 @@ func (s *svc2Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.importer.Svc2/Send":
+	case "/twirp.internal.twirptest.importer.Svc2/Send":
 		s.serveSend(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/importer/importer_pb2_twirp.py
+++ b/internal/twirptest/importer/importer_pb2_twirp.py
@@ -49,7 +49,7 @@ class Svc2Client(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -139,7 +139,7 @@ func (s *svc1Server) writeError(ctx context.Context, resp http.ResponseWriter, e
 // Svc1PathPrefix is used for all URL paths on a twirp Svc1 server.
 // Requests are always: POST Svc1PathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const Svc1PathPrefix = "/twirp/twirp.internal.twirptest.multiple.Svc1/"
+const Svc1PathPrefix = "/twirp.internal.twirptest.multiple.Svc1/"
 
 func (s *svc1Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -162,7 +162,7 @@ func (s *svc1Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.multiple.Svc1/Send":
+	case "/twirp.internal.twirptest.multiple.Svc1/Send":
 		s.serveSend(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/multiple/multiple1_pb2_twirp.py
+++ b/internal/twirptest/multiple/multiple1_pb2_twirp.py
@@ -49,7 +49,7 @@ class Svc1Client(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -144,7 +144,7 @@ func (s *svc2Server) writeError(ctx context.Context, resp http.ResponseWriter, e
 // Svc2PathPrefix is used for all URL paths on a twirp Svc2 server.
 // Requests are always: POST Svc2PathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const Svc2PathPrefix = "/twirp/twirp.internal.twirptest.multiple.Svc2/"
+const Svc2PathPrefix = "/twirp.internal.twirptest.multiple.Svc2/"
 
 func (s *svc2Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -167,10 +167,10 @@ func (s *svc2Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.multiple.Svc2/Send":
+	case "/twirp.internal.twirptest.multiple.Svc2/Send":
 		s.serveSend(ctx, resp, req)
 		return
-	case "/twirp/twirp.internal.twirptest.multiple.Svc2/SamePackageProtoImport":
+	case "/twirp.internal.twirptest.multiple.Svc2/SamePackageProtoImport":
 		s.serveSamePackageProtoImport(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/multiple/multiple2_pb2_twirp.py
+++ b/internal/twirptest/multiple/multiple2_pb2_twirp.py
@@ -49,7 +49,7 @@ class Svc2Client(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -135,7 +135,7 @@ func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, er
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
 // Requests are always: POST SvcPathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const SvcPathPrefix = "/twirp/Svc/"
+const SvcPathPrefix = "/Svc/"
 
 func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -158,7 +158,7 @@ func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/Svc/Send":
+	case "/Svc/Send":
 		s.serveSend(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/no_package_name/no_package_name_pb2_twirp.py
+++ b/internal/twirptest/no_package_name/no_package_name_pb2_twirp.py
@@ -49,7 +49,7 @@ class SvcClient(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -137,7 +137,7 @@ func (s *svc2Server) writeError(ctx context.Context, resp http.ResponseWriter, e
 // Svc2PathPrefix is used for all URL paths on a twirp Svc2 server.
 // Requests are always: POST Svc2PathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const Svc2PathPrefix = "/twirp/Svc2/"
+const Svc2PathPrefix = "/Svc2/"
 
 func (s *svc2Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -160,7 +160,7 @@ func (s *svc2Server) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/Svc2/Method":
+	case "/Svc2/Method":
 		s.serveMethod(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer_pb2_twirp.py
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer_pb2_twirp.py
@@ -49,7 +49,7 @@ class Svc2Client(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -138,7 +138,7 @@ func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, er
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
 // Requests are always: POST SvcPathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const SvcPathPrefix = "/twirp/twirp.internal.twirptest.proto.Svc/"
+const SvcPathPrefix = "/twirp.internal.twirptest.proto.Svc/"
 
 func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -161,7 +161,7 @@ func (s *svcServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.proto.Svc/Send":
+	case "/twirp.internal.twirptest.proto.Svc/Send":
 		s.serveSend(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/proto/proto_pb2_twirp.py
+++ b/internal/twirptest/proto/proto_pb2_twirp.py
@@ -49,7 +49,7 @@ class SvcClient(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -137,7 +137,7 @@ func (s *haberdasherServer) writeError(ctx context.Context, resp http.ResponseWr
 // HaberdasherPathPrefix is used for all URL paths on a twirp Haberdasher server.
 // Requests are always: POST HaberdasherPathPrefix/method
 // It can be used in an HTTP mux to route twirp requests along with non-twirp requests on other routes.
-const HaberdasherPathPrefix = "/twirp/twirp.internal.twirptest.Haberdasher/"
+const HaberdasherPathPrefix = "/twirp.internal.twirptest.Haberdasher/"
 
 func (s *haberdasherServer) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -160,7 +160,7 @@ func (s *haberdasherServer) ServeHTTP(resp http.ResponseWriter, req *http.Reques
 	}
 
 	switch req.URL.Path {
-	case "/twirp/twirp.internal.twirptest.Haberdasher/MakeHat":
+	case "/twirp.internal.twirptest.Haberdasher/MakeHat":
 		s.serveMakeHat(ctx, resp, req)
 		return
 	default:

--- a/internal/twirptest/service_pb2_twirp.py
+++ b/internal/twirptest/service_pb2_twirp.py
@@ -53,7 +53,7 @@ class HaberdasherClient(object):
 
     def __make_request(self, body, full_method):
         req = Request(
-            url=self.__target + "/twirp" + full_method,
+            url=self.__target + full_method,
             data=body,
             headers={"Content-Type": "application/protobuf"},
         )

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -881,7 +881,7 @@ func (t *twirp) generateServer(file *descriptor.FileDescriptorProto, service *de
 // service. It includes a trailing slash. (for example
 // "/twirp/twitch.example.Haberdasher/").
 func pathPrefix(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) string {
-	return fmt.Sprintf("/twirp/%s/", fullServiceName(file, service))
+	return fmt.Sprintf("/%s/", fullServiceName(file, service))
 }
 
 // pathFor returns the complete path for requests to a particular method on a

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -879,7 +879,7 @@ func (t *twirp) generateServer(file *descriptor.FileDescriptorProto, service *de
 
 // pathPrefix returns the base path for all methods handled by a particular
 // service. It includes a trailing slash. (for example
-// "/twirp/twitch.example.Haberdasher/").
+// "/twitch.example.Haberdasher/").
 func pathPrefix(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) string {
 	return fmt.Sprintf("/%s/", fullServiceName(file, service))
 }

--- a/protoc-gen-twirp_python/main.go
+++ b/protoc-gen-twirp_python/main.go
@@ -138,7 +138,7 @@ func (g *generator) generateProtobufClient(file *descriptor.FileDescriptorProto,
 	g.P()
 	g.P(`    def __make_request(self, body, full_method):`)
 	g.P(`        req = Request(`)
-	g.P(`            url=self.__target + "/twirp" + full_method,`)
+	g.P(`            url=self.__target + full_method,`)
 	g.P(`            data=body,`)
 	g.P(`            headers={"Content-Type": "application/protobuf"},`)
 	g.P(`        )`)


### PR DESCRIPTION
*Issue #, if available:*

#86 

*Description of changes:*

This change implements the plan discussed in #86: It removes the /twirp prefix from routes.

This would be merged into a 'v6_prerelease' branch, not master.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
