### PR TITLE
Make the python client code ascii-encode server urls.

### DIFF
--- a/protoc-gen-twirp_python/main.go
+++ b/protoc-gen-twirp_python/main.go
@@ -134,7 +134,7 @@ func (g *generator) generateProtobufClient(file *descriptor.FileDescriptorProto,
 	g.P(`            server_address: The address of the server to send requests to, in`)
 	g.P(`                the full protocol://host:port form.`)
 	g.P(`        """`)
-	g.P(`        self.__target = server_address`)
+	g.P(`        self.__target = server_address.encode('ascii')`)
 	g.P(`        self.__service_name = `, strconv.Quote(fullServiceName(file, service)))
 	g.P()
 	g.P(`    def __make_request(self, body, full_method):`)


### PR DESCRIPTION
Without this, if passed a unicode string object as the address for the
Twirp server, the client will break on python2 if a proto message
definition has a field with id 16 or greater, if it contains varints
(int32, etc) with value over 127, or simply has binary byte fields with
non-ascii characters.

The root of the problem is that Python2's unicode types are infectious.
If the url passed is a unicode() type and not a str() type, urllib will
silently make the entire set of headers unicode when the Host header is
appended.   When the protobuf encoded body is appended later, it will
attempt to encode it as unicode and may fail.

The error message you'll get will look something like this:

```
  File "/usr/lib/python2.7/httplib.py", line 1038, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 880, in _send_output
    msg += message_body
UnicodeDecodeError: 'ascii' codec can't decode byte 0x92 in position 170: ordinal not in range(128)
```

This solves the problem by forcibly encoding the URL of the server in
ASCII, which matches what is allowed to be in DNS names and URLs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
