### PR TITLE
Ruby Twirp now supports clients as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ For other languages, there are third-party generators available:
 | **JavaScript** |    ✓    |         | [github.com/thechriswalker/protoc-gen-twirp_js](https://github.com/thechriswalker/protoc-gen-twirp_js)
 | **JavaScript** |    ✓    |         | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_jsbrowser](https://github.com/Xe/twirp-codegens)
 | **Typescript** |    ✓    |         | [github.com/larrymyers/protoc-gen-twirp_typescript](https://github.com/larrymyers/protoc-gen-twirp_typescript)
-| **Ruby**       |         |    ✓    | [github.com/cyrusaf/ruby-twirp](https://github.com/cyrusaf/ruby-twirp)
-| **Ruby**       |    ✓    |         | [github.com/gaffneyc/protoc-gen-twirp_ruby](https://github.com/gaffneyc/protoc-gen-twirp_ruby)
+| **Ruby**       |    ✓    |    ✓    | [github.com/cyrusaf/ruby-twirp](https://github.com/cyrusaf/ruby-twirp)
 | **Rust**       |    ✓    |    ✓    | [github.com/cretz/prost-twirp](https://github.com/cretz/prost-twirp)
 | **Swagger**    |    ✓    |    ✓    | [github.com/elliots/protoc-gen-twirp_swagger](https://github.com/elliots/protoc-gen-twirp_swagger)
 


### PR DESCRIPTION
Just released ruby-twirp 0.2.0 that implements [Twirp::Client](https://github.com/cyrusaf/ruby-twirp/pull/5). It is fully functional for proto requests.

The implementation for `Twirp::Client` uses `Twirp::Error` just like `Twirp::Service`. I think at this point we should recommend using this Twirp instead of `github.com/gaffneyc/protoc-gen-twirp_ruby` that generates a client that is not compatible with the error in here. But please LMK if you want to keep that project in the list as well and I'll add it back.