### PR TITLE
Nil responses on errors

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -73,7 +73,10 @@ func (c *compatServiceProtobufClient) Method(ctx context.Context, in *Req) (*Res
 	ctx = ctxsetters.WithMethodName(ctx, "Method")
 	out := new(Resp)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *compatServiceProtobufClient) NoopMethod(ctx context.Context, in *Empty) (*Empty, error) {
@@ -82,7 +85,10 @@ func (c *compatServiceProtobufClient) NoopMethod(ctx context.Context, in *Empty)
 	ctx = ctxsetters.WithMethodName(ctx, "NoopMethod")
 	out := new(Empty)
 	err := doProtobufRequest(ctx, c.client, c.urls[1], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // =========================
@@ -120,7 +126,10 @@ func (c *compatServiceJSONClient) Method(ctx context.Context, in *Req) (*Resp, e
 	ctx = ctxsetters.WithMethodName(ctx, "Method")
 	out := new(Resp)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *compatServiceJSONClient) NoopMethod(ctx context.Context, in *Empty) (*Empty, error) {
@@ -129,7 +138,10 @@ func (c *compatServiceJSONClient) NoopMethod(ctx context.Context, in *Empty) (*E
 	ctx = ctxsetters.WithMethodName(ctx, "NoopMethod")
 	out := new(Empty)
 	err := doJSONRequest(ctx, c.client, c.urls[1], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ============================

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -72,7 +72,10 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // =======================
@@ -109,7 +112,10 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ==========================

--- a/internal/twirptest/client_test.go
+++ b/internal/twirptest/client_test.go
@@ -41,6 +41,56 @@ func (i *reqInspector) RoundTrip(r *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(r)
 }
 
+func TestClientSuccessAndErrorResponses(t *testing.T) {
+	// Service that succeeds only if requested size is 1, otherwise errors
+	h := PickyHatmaker(1)
+	s := httptest.NewServer(NewHaberdasherServer(h, nil, nil))
+	defer s.Close()
+
+	// Clients
+	protoCli := NewHaberdasherProtobufClient(s.URL, &http.Client{})
+	jsonCli := NewHaberdasherJSONClient(s.URL, &http.Client{})
+	ctx := context.Background()
+	var resp *Hat
+	var err error
+
+	// Test proto success
+	resp, err = protoCli.MakeHat(ctx, &Size{1})
+	if err != nil {
+		t.Fatalf("Proto client method returned unexpected error: %s", err)
+	}
+	if resp == nil {
+		t.Fatalf("Proto client method expected to return non-nil response, but it is nil")
+	}
+
+	// Test proto failure
+	resp, err = protoCli.MakeHat(ctx, &Size{666})
+	if err == nil {
+		t.Fatalf("Proto client method expected to fail, but error is nil")
+	}
+	if resp != nil {
+		t.Fatalf("Proto client method expected to return nil response on error, but returned non-nil")
+	}
+
+	// Test json success
+	resp, err = jsonCli.MakeHat(ctx, &Size{1})
+	if err != nil {
+		t.Fatalf("JSON client method returned unexpected error: %s", err)
+	}
+	if resp == nil {
+		t.Fatalf("JSON client method expected to return non-nil response, but it is nil")
+	}
+
+	// Test json failure
+	resp, err = jsonCli.MakeHat(ctx, &Size{666})
+	if err == nil {
+		t.Fatalf("JSON client method expected to fail, but error is nil")
+	}
+	if resp != nil {
+		t.Fatalf("JSON client method expected to return nil response on error, but returned non-nil")
+	}
+}
+
 func TestClientSetsRequestContext(t *testing.T) {
 	// Start up a server just so we can make a working client later.
 	h := PickyHatmaker(1)

--- a/internal/twirptest/client_test.go
+++ b/internal/twirptest/client_test.go
@@ -44,7 +44,7 @@ func (i *reqInspector) RoundTrip(r *http.Request) (*http.Response, error) {
 func TestClientSuccessAndErrorResponses(t *testing.T) {
 	// Service that succeeds only if requested size is 1, otherwise errors
 	h := PickyHatmaker(1)
-	s := httptest.NewServer(NewHaberdasherServer(h, nil, nil))
+	s := httptest.NewServer(NewHaberdasherServer(h, nil))
 	defer s.Close()
 
 	// Clients

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -74,7 +74,10 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===============
@@ -111,7 +114,10 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ==================

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -73,7 +73,10 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===============
@@ -110,7 +113,10 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ==================

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -75,7 +75,10 @@ func (c *svc2ProtobufClient) Send(ctx context.Context, in *twirp_internal_twirpt
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(twirp_internal_twirptest_importable.Msg)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ================
@@ -112,7 +115,10 @@ func (c *svc2JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(twirp_internal_twirptest_importable.Msg)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===================

--- a/internal/twirptest/importmapping/x/x.twirp.go
+++ b/internal/twirptest/importmapping/x/x.twirp.go
@@ -72,7 +72,10 @@ func (c *svc1ProtobufClient) Send(ctx context.Context, in *twirp_internal_twirpt
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(twirp_internal_twirptest_importmapping_y.MsgY)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ================
@@ -109,7 +112,10 @@ func (c *svc1JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(twirp_internal_twirptest_importmapping_y.MsgY)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===================

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -74,7 +74,10 @@ func (c *svc1ProtobufClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) 
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg1)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ================
@@ -111,7 +114,10 @@ func (c *svc1JSONClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg1)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===================

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -60,7 +60,10 @@ func (c *svc2ProtobufClient) Send(ctx context.Context, in *Msg2) (*Msg2, error) 
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg2)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *svc2ProtobufClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (*Msg1, error) {
@@ -69,7 +72,10 @@ func (c *svc2ProtobufClient) SamePackageProtoImport(ctx context.Context, in *Msg
 	ctx = ctxsetters.WithMethodName(ctx, "SamePackageProtoImport")
 	out := new(Msg1)
 	err := doProtobufRequest(ctx, c.client, c.urls[1], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ================
@@ -107,7 +113,10 @@ func (c *svc2JSONClient) Send(ctx context.Context, in *Msg2) (*Msg2, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg2)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *svc2JSONClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (*Msg1, error) {
@@ -116,7 +125,10 @@ func (c *svc2JSONClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (
 	ctx = ctxsetters.WithMethodName(ctx, "SamePackageProtoImport")
 	out := new(Msg1)
 	err := doJSONRequest(ctx, c.client, c.urls[1], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===================

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -70,7 +70,10 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===============
@@ -107,7 +110,10 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ==================

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -72,7 +72,10 @@ func (c *svc2ProtobufClient) Method(ctx context.Context, in *no_package_name.Msg
 	ctx = ctxsetters.WithMethodName(ctx, "Method")
 	out := new(no_package_name.Msg)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ================
@@ -109,7 +112,10 @@ func (c *svc2JSONClient) Method(ctx context.Context, in *no_package_name.Msg) (*
 	ctx = ctxsetters.WithMethodName(ctx, "Method")
 	out := new(no_package_name.Msg)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===================

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -73,7 +73,10 @@ func (c *svcProtobufClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ===============
@@ -110,7 +113,10 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	ctx = ctxsetters.WithMethodName(ctx, "Send")
 	out := new(Msg)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ==================

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -72,7 +72,10 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
 	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // =======================
@@ -109,7 +112,10 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
 	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
-	return out, err
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ==========================

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -849,7 +849,10 @@ func (t *twirp) generateClient(name string, file *descriptor.FileDescriptorProto
 		t.P(`  ctx = `, t.pkgs["ctxsetters"], `.WithMethodName(ctx, "`, methName, `")`)
 		t.P(`  out := new(`, outputType, `)`)
 		t.P(`  err := do`, name, `Request(ctx, c.client, c.urls[`, strconv.Itoa(i), `], in, out)`)
-		t.P(`  return out, err`)
+		t.P(`  if err != nil {`)
+		t.P(`    return nil, err`)
+		t.P(`  }`)
+		t.P(`  return out, nil`)
 		t.P(`}`)
 		t.P()
 	}


### PR DESCRIPTION
Currently when the service returns `nil, err`, the client is returning `new(Message), err`. This can be confusing when handling errors in the client code, where the response is expected to be nil instead of a pointer to a zero-values-struct.

Since the Twirp wire protocol does not allow to send partial-responses with errors at the same time, the easy fix is to just return `nil` in the client if there's an error.

*Warning*: The zero-value-struct will be replaced for `nil`. This means that if any code was wrongly accessing the zero-value-struct on errors it will now panic.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.