### PR TITLE
Add doc page with a cURL example

### DIFF
--- a/docs/curl.md
+++ b/docs/curl.md
@@ -1,0 +1,80 @@
+---
+id: "curl"
+title: "cURL"
+sidebar_label: "cURL"
+---
+
+Twirp allows you to cURL your service with either Protobuf or JSON.
+
+## Example
+
+A cURL request to the Haberdasher example `MakeHat` RPC with the following request and reply could be executed as Protobuf or JSON with the snippets further below.:
+
+Request proto:
+```
+message Size {
+   int32 inches = 1;
+}
+```
+
+Reply proto:
+
+```
+message Hat {
+  int32 inches = 1;
+  string color = 2;
+  string name = 3;
+}
+```
+
+### Protobuf
+
+```sh
+echo "inches:10" \
+	| protoc --proto_path=$GOPATH/src --encode twirp.example.haberdasher.Size ./rpc/haberdasher/service.proto \
+	| curl -s --request POST \
+                  --header "Content-Type: application/protobuf" \
+                  --data-binary @-
+                  http://localhost:8080/twirp/twirp.example.haberdasher.Haberdasher/MakeHat \
+	| protoc --proto_path=$GOPATH/src --decode twirp.example.haberdasher.Hat ./rpc/haberdasher/service.proto
+```
+
+We signal Twirp that we're sending Protobuf data by setting the `Content-Type` as `application/protobuf`.
+
+The request is:
+
+```
+inches:10
+```
+
+The reply from Twirp would look something like this:
+
+```
+inches:1
+color:"black"
+name:"bowler"
+```
+
+### JSON
+
+```sh
+curl --request "POST" \
+     --location "http://localhost:8080/twirp/twirp.example.haberdasher.Haberdasher/MakeHat" \
+     --header "Content-Type:application/json" \
+     --data '{"inches": 10}' \
+     --verbose
+```
+
+We signal Twirp that we're sending JSON data by setting the `Content-Type` as `application/json`.
+
+The request is:
+
+```json
+{"inches": 10}
+```
+
+The JSON response from Twirp would look something like this:
+
+```json
+{"inches":1, "color":"black", "name":"bowler"}
+```

--- a/docs/protobuf_and_json.md
+++ b/docs/protobuf_and_json.md
@@ -35,10 +35,9 @@ versions (that doesn't work with JSON clients).
 
 You will probably never need to use a Twirp **JSONClient** in Go, but having
 your servers automatically handle JSON requests is still very convenient. It
-makes it easier to debug (see
-[cURL requests](https://github.com/twitchtv/twirp/wiki/HTTP-Routing-and-Serialization#making-requests-on-the-command-line-with-curl)),
-allows to easily write clients in other languages like Python, or make REST
-mappings to Twirp services.
+makes it easier to debug (see [cURL requests](curl.md)), allows to easily write
+clients in other languages like Python, or make REST mappings to Twirp
+services.
 
 The JSON client is generated to provide a reference for implementations in other
 languages, and because in some rare circumstances, binary encoding of request

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,7 +13,8 @@
             "errors",
             "hooks",
             "command_line",
-            "proto_and_json"
+            "proto_and_json",
+            "curl"
         ],
         "Formal specification": [
             "spec_v5",


### PR DESCRIPTION
What
===
Add doc page with a cURL exaple.

Why
===
cURLing is an important part of being able to debug a service. It's
worth providing examples using JSON and Protobufs as it can be daunting
figuring out how to do both correctly.

Resolves #22