### PR TITLE
Improve support for go_package option in .proto files

### DIFF
--- a/protoc-gen-twirp/command_line.go
+++ b/protoc-gen-twirp/command_line.go
@@ -21,6 +21,7 @@ import (
 type commandLineParams struct {
 	importPrefix string            // String to prefix to imported package file names.
 	importMap    map[string]string // Mapping from .proto file name to import path.
+	paths        string            // Paths value, used to control file output directory
 }
 
 // parseCommandLineParams breaks the comma-separated list of key=value pairs
@@ -56,6 +57,11 @@ func parseCommandLineParams(parameter string) (*commandLineParams, error) {
 			clp.importMap[k[1:]] = v // 1 is the length of 'M'.
 		case len(k) > 0 && strings.HasPrefix(k, "go_import_mapping@"):
 			clp.importMap[k[18:]] = v // 18 is the length of 'go_import_mapping@'.
+		case k == "paths":
+			if v != "source_relative" {
+				return nil, fmt.Errorf("paths does not support %q", v)
+			}
+			clp.paths = v
 		default:
 			return nil, fmt.Errorf("unknown parameter %q", k)
 		}

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -48,7 +48,7 @@ type twirp struct {
 	importMap    map[string]string // Mapping from .proto file name to import path.
 
 	// Package output:
-	paths string // instruction on where to write output files
+	sourceRelativePaths bool // instruction on where to write output files
 
 	// Package naming:
 	genPkgName          string // Name of the package that we're generating
@@ -85,7 +85,7 @@ func (t *twirp) Generate(in *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorR
 
 	t.genFiles = gen.FilesToGenerate(in)
 
-	t.paths = params.paths
+	t.sourceRelativePaths = params.paths == "source_relative"
 
 	// Collect information on types.
 	t.reg = typemap.New(in.ProtoFile)

--- a/protoc-gen-twirp/go_naming.go
+++ b/protoc-gen-twirp/go_naming.go
@@ -65,13 +65,15 @@ func goPackageName(f *descriptor.FileDescriptorProto) (name string, explicit boo
 }
 
 // goFileName returns the output name for the generated Go file.
-func goFileName(f *descriptor.FileDescriptorProto) string {
+func (t *twirp) goFileName(f *descriptor.FileDescriptorProto) string {
 	name := *f.Name
 	if ext := path.Ext(name); ext == ".proto" || ext == ".protodevel" {
 		name = name[:len(name)-len(ext)]
 	}
 	name += ".twirp.go"
-
+	if t.paths == "source_relative" {
+		return name
+	}
 	// Does the file have a "go_package" option? If it does, it may override the
 	// filename.
 	if impPath, _, ok := goPackageOption(f); ok && impPath != "" {

--- a/protoc-gen-twirp/go_naming.go
+++ b/protoc-gen-twirp/go_naming.go
@@ -71,7 +71,7 @@ func (t *twirp) goFileName(f *descriptor.FileDescriptorProto) string {
 		name = name[:len(name)-len(ext)]
 	}
 	name += ".twirp.go"
-	if t.paths == "source_relative" {
+	if t.sourceRelativePaths {
 		return name
 	}
 	// Does the file have a "go_package" option? If it does, it may override the


### PR DESCRIPTION
Previously, specifying the option go_package caused the generator
to write a file to the fully qualified path
This would create the full directory tree

this doesn't really work as it adds, to your project root dir, the full github.com/blah/...
structure

This change does two things
adds support for the `paths=source_relative` like the google protoc plugin does
which ensures we write to whatever directory the .proto file lives in

secondly, it makes sure to use whatever go_package says when importing the module.
It was generating imports with relative dirs from the project root

With these two changes, you can use twirp with go 1.11's modules now


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
