### PR TITLE
Generate Go stubs 

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -144,6 +144,23 @@ func (c *compatServiceJSONClient) NoopMethod(ctx context.Context, in *Empty) (*E
 	return out, nil
 }
 
+// ==================
+// CompatService Stub
+// ==================
+
+type CompatServiceStub struct {
+	OnMethod     func(context.Context, *Req) (*Resp, error)
+	OnNoopMethod func(context.Context, *Empty) (*Empty, error)
+}
+
+func (s *CompatServiceStub) Method(ctx context.Context, in *Req) (*Resp, error) {
+	return s.OnMethod(ctx, in)
+}
+
+func (s *CompatServiceStub) NoopMethod(ctx context.Context, in *Empty) (*Empty, error) {
+	return s.OnNoopMethod(ctx, in)
+}
+
 // ============================
 // CompatService Server Handler
 // ============================

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -118,6 +118,18 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	return out, nil
 }
 
+// ================
+// Haberdasher Stub
+// ================
+
+type HaberdasherStub struct {
+	OnMakeHat func(context.Context, *Size) (*Hat, error)
+}
+
+func (s *HaberdasherStub) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
+	return s.OnMakeHat(ctx, in)
+}
+
 // ==========================
 // Haberdasher Server Handler
 // ==========================

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -120,6 +120,18 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	return out, nil
 }
 
+// ========
+// Svc Stub
+// ========
+
+type SvcStub struct {
+	OnSend func(context.Context, *Msg) (*Msg, error)
+}
+
+func (s *SvcStub) Send(ctx context.Context, in *Msg) (*Msg, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ==================
 // Svc Server Handler
 // ==================

--- a/internal/twirptest/google_protobuf_imports/service.twirp.go
+++ b/internal/twirptest/google_protobuf_imports/service.twirp.go
@@ -119,6 +119,18 @@ func (c *svcJSONClient) Send(ctx context.Context, in *google_protobuf1.StringVal
 	return out, nil
 }
 
+// ========
+// Svc Stub
+// ========
+
+type SvcStub struct {
+	OnSend func(context.Context, *google_protobuf1.StringValue) (*google_protobuf.Empty, error)
+}
+
+func (s *SvcStub) Send(ctx context.Context, in *google_protobuf1.StringValue) (*google_protobuf.Empty, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ==================
 // Svc Server Handler
 // ==================

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -119,6 +119,18 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	return out, nil
 }
 
+// ========
+// Svc Stub
+// ========
+
+type SvcStub struct {
+	OnSend func(context.Context, *Msg) (*Msg, error)
+}
+
+func (s *SvcStub) Send(ctx context.Context, in *Msg) (*Msg, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ==================
 // Svc Server Handler
 // ==================

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -121,6 +121,18 @@ func (c *svc2JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_
 	return out, nil
 }
 
+// =========
+// Svc2 Stub
+// =========
+
+type Svc2Stub struct {
+	OnSend func(context.Context, *twirp_internal_twirptest_importable.Msg) (*twirp_internal_twirptest_importable.Msg, error)
+}
+
+func (s *Svc2Stub) Send(ctx context.Context, in *twirp_internal_twirptest_importable.Msg) (*twirp_internal_twirptest_importable.Msg, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ===================
 // Svc2 Server Handler
 // ===================

--- a/internal/twirptest/importmapping/x/x.twirp.go
+++ b/internal/twirptest/importmapping/x/x.twirp.go
@@ -118,6 +118,18 @@ func (c *svc1JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_
 	return out, nil
 }
 
+// =========
+// Svc1 Stub
+// =========
+
+type Svc1Stub struct {
+	OnSend func(context.Context, *twirp_internal_twirptest_importmapping_y.MsgY) (*twirp_internal_twirptest_importmapping_y.MsgY, error)
+}
+
+func (s *Svc1Stub) Send(ctx context.Context, in *twirp_internal_twirptest_importmapping_y.MsgY) (*twirp_internal_twirptest_importmapping_y.MsgY, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ===================
 // Svc1 Server Handler
 // ===================

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -120,6 +120,18 @@ func (c *svc1JSONClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
 	return out, nil
 }
 
+// =========
+// Svc1 Stub
+// =========
+
+type Svc1Stub struct {
+	OnSend func(context.Context, *Msg1) (*Msg1, error)
+}
+
+func (s *Svc1Stub) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ===================
 // Svc1 Server Handler
 // ===================

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -131,6 +131,23 @@ func (c *svc2JSONClient) SamePackageProtoImport(ctx context.Context, in *Msg1) (
 	return out, nil
 }
 
+// =========
+// Svc2 Stub
+// =========
+
+type Svc2Stub struct {
+	OnSend                   func(context.Context, *Msg2) (*Msg2, error)
+	OnSamePackageProtoImport func(context.Context, *Msg1) (*Msg1, error)
+}
+
+func (s *Svc2Stub) Send(ctx context.Context, in *Msg2) (*Msg2, error) {
+	return s.OnSend(ctx, in)
+}
+
+func (s *Svc2Stub) SamePackageProtoImport(ctx context.Context, in *Msg1) (*Msg1, error) {
+	return s.OnSamePackageProtoImport(ctx, in)
+}
+
 // ===================
 // Svc2 Server Handler
 // ===================

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -116,6 +116,18 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	return out, nil
 }
 
+// ========
+// Svc Stub
+// ========
+
+type SvcStub struct {
+	OnSend func(context.Context, *Msg) (*Msg, error)
+}
+
+func (s *SvcStub) Send(ctx context.Context, in *Msg) (*Msg, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ==================
 // Svc Server Handler
 // ==================

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -118,6 +118,18 @@ func (c *svc2JSONClient) Method(ctx context.Context, in *no_package_name.Msg) (*
 	return out, nil
 }
 
+// =========
+// Svc2 Stub
+// =========
+
+type Svc2Stub struct {
+	OnMethod func(context.Context, *no_package_name.Msg) (*no_package_name.Msg, error)
+}
+
+func (s *Svc2Stub) Method(ctx context.Context, in *no_package_name.Msg) (*no_package_name.Msg, error) {
+	return s.OnMethod(ctx, in)
+}
+
 // ===================
 // Svc2 Server Handler
 // ===================

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -119,6 +119,18 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 	return out, nil
 }
 
+// ========
+// Svc Stub
+// ========
+
+type SvcStub struct {
+	OnSend func(context.Context, *Msg) (*Msg, error)
+}
+
+func (s *SvcStub) Send(ctx context.Context, in *Msg) (*Msg, error) {
+	return s.OnSend(ctx, in)
+}
+
 // ==================
 // Svc Server Handler
 // ==================

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -118,6 +118,18 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	return out, nil
 }
 
+// ================
+// Haberdasher Stub
+// ================
+
+type HaberdasherStub struct {
+	OnMakeHat func(context.Context, *Size) (*Hat, error)
+}
+
+func (s *HaberdasherStub) MakeHat(ctx context.Context, in *Size) (*Hat, error) {
+	return s.OnMakeHat(ctx, in)
+}
+
 // ==========================
 // Haberdasher Server Handler
 // ==========================

--- a/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
+++ b/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
@@ -116,6 +116,18 @@ func (c *echoJSONClient) Echo(ctx context.Context, in *Msg) (*Msg, error) {
 	return out, nil
 }
 
+// =========
+// Echo Stub
+// =========
+
+type EchoStub struct {
+	OnEcho func(context.Context, *Msg) (*Msg, error)
+}
+
+func (s *EchoStub) Echo(ctx context.Context, in *Msg) (*Msg, error) {
+	return s.OnEcho(ctx, in)
+}
+
 // ===================
 // Echo Server Handler
 // ===================

--- a/internal/twirptest/source_relative/source_relative.twirp.go
+++ b/internal/twirptest/source_relative/source_relative.twirp.go
@@ -116,6 +116,18 @@ func (c *svcJSONClient) Method(ctx context.Context, in *Msg) (*Msg, error) {
 	return out, nil
 }
 
+// ========
+// Svc Stub
+// ========
+
+type SvcStub struct {
+	OnMethod func(context.Context, *Msg) (*Msg, error)
+}
+
+func (s *SvcStub) Method(ctx context.Context, in *Msg) (*Msg, error) {
+	return s.OnMethod(ctx, in)
+}
+
 // ==================
 // Svc Server Handler
 // ==================


### PR DESCRIPTION
Generates a simple stub that provides a type safe and simple way to fake out a server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.