### PR TITLE
Add emit_json_defaults option

### DIFF
--- a/protoc-gen-twirp/command_line.go
+++ b/protoc-gen-twirp/command_line.go
@@ -19,9 +19,10 @@ import (
 )
 
 type commandLineParams struct {
-	importPrefix string            // String to prefix to imported package file names.
-	importMap    map[string]string // Mapping from .proto file name to import path.
-	paths        string            // Paths value, used to control file output directory
+	importPrefix     string            // String to prefix to imported package file names.
+	importMap        map[string]string // Mapping from .proto file name to import path.
+	paths            string            // Paths value, used to control file output directory
+	emitJSONDefaults bool              // Whether to render json fields with zero values.
 }
 
 // parseCommandLineParams breaks the comma-separated list of key=value pairs
@@ -62,6 +63,8 @@ func parseCommandLineParams(parameter string) (*commandLineParams, error) {
 				return nil, fmt.Errorf("paths does not support %q", v)
 			}
 			clp.paths = v
+		case k == "emit_json_defaults":
+			clp.emitJSONDefaults = true
 		default:
 			return nil, fmt.Errorf("unknown parameter %q", k)
 		}

--- a/protoc-gen-twirp/command_line_test.go
+++ b/protoc-gen-twirp/command_line_test.go
@@ -62,6 +62,15 @@ func TestParseCommandLineParams(t *testing.T) {
 			nil,
 		},
 		{
+			"emit_json_defaults parameter",
+			"emit_json_defaults=true",
+			&commandLineParams{
+				importMap:        map[string]string{},
+				emitJSONDefaults: true,
+			},
+			nil,
+		},
+		{
 			"single import parameter starting with 'M'",
 			"Mrpcutil/empty.proto=github.com/example/rpcutil",
 			&commandLineParams{


### PR DESCRIPTION
The package jsonpb which is used to un/marshal json values
into protobuf structures has the option to emit default values
within generated json structures. This CL adds support for
this feature by adding emit_json_defaults as command line flag.
Use for e.g. with `--twirp_out=emit_json_defaults=ENABLE:.`.
Notice that once a value is set this feature is turned on. To
disable it just omit `emit_json_defaults` like for e.g.
`--twirp_out=.`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
