### PR TITLE
adding Dart client to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For other languages, there are third-party generators available:
 | **Rust**       |    ✓    |    ✓    | [github.com/cretz/prost-twirp](https://github.com/cretz/prost-twirp)
 | **Swagger**    |    ✓    |    ✓    | [github.com/elliots/protoc-gen-twirp_swagger](https://github.com/elliots/protoc-gen-twirp_swagger)
 | **PHP**        |    ✓    |    ✓    | [github.com/twirphp/twirp](https://github.com/twirphp/twirp)
+| **Dart**       |    ✓    |         | [github.com/apptreesoftware/protoc-gen-twirp_dart](https://github.com/apptreesoftware/protoc-gen-twirp_dart)
 
 This list isn't an endorsement, it's just a convenience to help you find stuff
 for your language.


### PR DESCRIPTION
Resolves #136 

Adds Dart client to README.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
