### PR TITLE
Fix code syntax in documentation example

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -25,7 +25,7 @@
 //
 //     resp, err := twirpClient.RPCMethod(ctx, req)
 //     if err != nil {
-//         if twerr := err.(twirp.Error) {
+//         if twerr, ok := err.(twirp.Error); ok {
 //             switch twerr.Code() {
 //             case twirp.InvalidArgument:
 //                 log.Error("invalid argument "+twirp.Meta("argument"))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just fixing this little syntax error in the documentation... 🙂

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
