### PR TITLE
Add release generation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ clientcompat/pycompat/ENV
 build
 
 npm-debug.log
+
+/release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,13 @@ Twirp uses Github releases. To make a new release:
  3. Add a new commit to master with a message like "Version vX.X.X release".
  4. Tag the commit you just made: `git tag <version number>` and `git push
     origin --tags`
- 5. Go to Github https://github.com/twitchtv/twirp/releases and
+ 5. Run `make release_gen` to generate release assets in the `release`
+    directory. This requires Docker to be installed.
+ 6. Go to Github https://github.com/twitchtv/twirp/releases and
     "Draft a new release".
- 6. Make sure to document changes, specially when upgrade instructions are
+ 7. Make sure to document changes, specially when upgrade instructions are
     needed.
+ 8. Upload all files in the `release` directory as part of the release.
 
 
 ## Code of Conduct

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 RETOOL=$(CURDIR)/_tools/bin/retool
 PATH := ${PWD}/bin:${PWD}/ENV/bin:${PATH}
+DOCKER_RELEASE_IMAGE := golang:1.12.0-stretch
 .DEFAULT_GOAL := all
 
 all: setup test_all
 
-.PHONY: test test_all test_core test_clients test_go_client test_python_client generate
+.PHONY: test test_all test_core test_clients test_go_client test_python_client generate release_gen
 
 # Phony commands:
 generate:
@@ -29,6 +30,14 @@ setup:
 	./install_proto.bash
 	GOPATH=$(CURDIR)/_tools go install github.com/twitchtv/retool/...
 	$(RETOOL) build
+
+release_gen:
+	git clean -xdf
+	docker run \
+		--volume "$(CURDIR):/go/src/github.com/twitchtv/twirp" \
+		--workdir "/go/src/github.com/twitchtv/twirp" \
+		$(DOCKER_RELEASE_IMAGE) \
+		internal/release_gen.sh
 
 # Actual files for testing clients:
 ./build:

--- a/internal/release_gen.sh
+++ b/internal/release_gen.sh
@@ -23,7 +23,7 @@ goarch() {
 sha256() {
   if ! type sha256sum >/dev/null 2>/dev/null; then
     if ! type shasum >/dev/null 2>/dev/null; then
-      fail "sha256sum and shasum are not installed"
+      echo "sha256sum and shasum are not installed" >&2
       return 1
     else
       shasum -a 256 "$@"

--- a/internal/release_gen.sh
+++ b/internal/release_gen.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${0}")/.." && pwd)"
+cd "${DIR}"
+
+goos() {
+  case "${1}" in
+    Darwin) echo darwin ;;
+    Linux) echo linux ;;
+    *) return 1 ;;
+  esac
+}
+
+goarch() {
+  case "${1}" in
+    x86_64) echo amd64 ;;
+    *) return 1 ;;
+  esac
+}
+
+sha256() {
+  if ! type sha256sum >/dev/null 2>/dev/null; then
+    if ! type shasum >/dev/null 2>/dev/null; then
+      fail "sha256sum and shasum are not installed"
+      return 1
+    else
+      shasum -a 256 "$@"
+    fi
+  else
+    sha256sum "$@"
+  fi
+}
+
+RELEASE_DIR="release"
+
+rm -rf "${RELEASE_DIR}"
+for os in Darwin Linux; do
+  for arch in x86_64; do
+    for binary_name in protoc-gen-twirp protoc-gen-twirp_python; do
+      BINARY="${RELEASE_DIR}/${binary_name}-${os}-${arch}"
+      CGO_ENABLED=0 GOOS=$(goos "${os}") GOARCH=$(goarch "${arch}") \
+        go build -a -installsuffix cgo -o "${BINARY}" \
+        $(find "${binary_name}" -name '*.go')
+      sha256 "${BINARY}" > "${BINARY}.sha256sum"
+      sha256 -c "${BINARY}.sha256sum"
+    done
+  done
+done


### PR DESCRIPTION
Fixes #152 assuming the next release includes the generated binaries and sha256sum files.

This adds a script to generate release assets for Twirp. The script `internal/release_gen.sh` generates a binary for each of Darwin/Linux in x86_64 along with a sha256sum file, and then verifies the sha256sum. It does this in a platform-independent manner.

The Makefile target `release_gen` calls `git clean xdf` to make the repository pristine (not strictly necessary, but not a bad practice overall), and calls this script inside a Docker container, both to make sure no external dependencies are being used, and to make sure that if either binary panics, the file paths are printed out as `/go/src/...` not `/Users/whoever/go/src` etc.

It would be best to get #153 merged first as this makes the most sense with that.