### PR TITLE
Fix readGenRequest to read request from io.Reader

### DIFF
--- a/internal/gen/main.go
+++ b/internal/gen/main.go
@@ -50,7 +50,7 @@ Outer:
 }
 
 func readGenRequest(r io.Reader) *plugin.CodeGeneratorRequest {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := ioutil.ReadAll(r)
 	if err != nil {
 		Error(err, "reading input")
 	}


### PR DESCRIPTION
Fix `readGenRequest` to read `plugin.CodeGeneratorRequest` from `io.Reader` not from `os.Stdin`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.