### PR TITLE
[DO NOT MERGE] RFC: Client Hooks Proof of Concept

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the License is
+// located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package twirp
+
+import (
+	"context"
+	"net/http"
+)
+
+// HTTPClient is the interface used by generated clients to send HTTP requests.
+// It is fulfilled by *(net/http).Client, which is sufficient for most users.
+// Users can provide their own implementation for special retry policies.
+//
+// HTTPClient implementations should not follow redirects. Redirects are
+// automatically disabled if *(net/http).Client is passed to client
+// constructors. See the withoutRedirects function in this file for more
+// details.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type ClientOption func(*ClientOptions)
+
+type ClientOptions struct {
+	Client HTTPClient
+	Hooks  *ClientHooks
+}
+
+type ClientHooks struct {
+	// RequestPrepared is called as soon as a request has been created and before it has been sent
+	// to the Twirp server.
+	RequestPrepared func(context.Context, *http.Request) (context.Context, error)
+
+	// RequestFinished (alternatively could be named ResponseReceived and take in some response from
+	// the server as well) is called after a request has finished sending. Since this is terminal, the context is
+	// not returned.
+	RequestFinished func(context.Context)
+
+	// Error hook is called whenever an error occurs during the sending of a request. The Error is passed
+	// as an argument to the hook.
+	Error func(context.Context, Error) context.Context
+}
+
+func DefaultClientOptions(client HTTPClient) ClientOptions {
+	return ClientOptions{
+		Client: client,
+		Hooks:  nil,
+	}
+}
+
+func WithClientHooks(hooks *ClientHooks) ClientOption {
+	return func(o *ClientOptions) {
+		o.Hooks = hooks
+	}
+}

--- a/internal/twirptest/client_test.go
+++ b/internal/twirptest/client_test.go
@@ -201,7 +201,7 @@ func TestClientSetsAcceptHeader(t *testing.T) {
 
 // If a server returns a 3xx response, give a clear error message
 func TestClientRedirectError(t *testing.T) {
-	testcase := func(code int, clientMaker func(string, HTTPClient) Haberdasher) func(*testing.T) {
+	testcase := func(code int, clientMaker func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
 		return func(t *testing.T) {
 			// Make a server that redirects all requests
 			redirecter := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +258,7 @@ func TestClientRedirectError(t *testing.T) {
 }
 
 func TestClientIntermediaryErrors(t *testing.T) {
-	testcase := func(code int, expectedErrorCode twirp.ErrorCode, clientMaker func(string, HTTPClient) Haberdasher) func(*testing.T) {
+	testcase := func(code int, expectedErrorCode twirp.ErrorCode, clientMaker func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
 		return func(t *testing.T) {
 			// Make a server that returns invalid twirp error responses,
 			// simulating a network intermediary.
@@ -486,7 +486,7 @@ func TestClientReturnsCloseErrors(t *testing.T) {
 // bodyCloseErrClient implements HTTPClient, but the response bodies it returns
 // give an error when they are closed.
 type bodyCloseErrClient struct {
-	base HTTPClient
+	base twirp.HTTPClient
 }
 
 func (c *bodyCloseErrClient) Do(req *http.Request) (*http.Response, error) {

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -138,7 +138,7 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	ctx = ctxsetters.WithServiceName(ctx, "Haberdasher")
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
-	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
+	err := doJSONRequest(ctx, c.opts.Client, c.urls[0], in, out)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -43,26 +43,33 @@ type Haberdasher interface {
 // ===========================
 
 type haberdasherProtobufClient struct {
-	client HTTPClient
+	client twirp.HTTPClient
 	urls   [1]string
+	opts   twirp.ClientOptions
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
 // It communicates using Protobuf and can be configured with a custom HTTPClient.
-func NewHaberdasherProtobufClient(addr string, client HTTPClient) Haberdasher {
+func NewHaberdasherProtobufClient(addr string, client twirp.HTTPClient, opt ...twirp.ClientOption) Haberdasher {
+	var httpClient twirp.HTTPClient = client
+
+	if c, ok := client.(*http.Client); ok {
+		httpClient = withoutRedirects(c)
+	}
+
+	opts := twirp.DefaultClientOptions(client)
+	for _, o := range opt {
+		o(&opts)
+	}
+
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
 		prefix + "MakeHat",
 	}
-	if httpClient, ok := client.(*http.Client); ok {
-		return &haberdasherProtobufClient{
-			client: withoutRedirects(httpClient),
-			urls:   urls,
-		}
-	}
 	return &haberdasherProtobufClient{
-		client: client,
+		client: httpClient,
 		urls:   urls,
+		opts:   opts,
 	}
 }
 
@@ -83,26 +90,33 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 // =======================
 
 type haberdasherJSONClient struct {
-	client HTTPClient
+	client twirp.HTTPClient
 	urls   [1]string
+	opts   twirp.ClientOptions
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
 // It communicates using JSON and can be configured with a custom HTTPClient.
-func NewHaberdasherJSONClient(addr string, client HTTPClient) Haberdasher {
+func NewHaberdasherJSONClient(addr string, client twirp.HTTPClient, opt ...twirp.ClientOption) Haberdasher {
+	var httpClient twirp.HTTPClient = client
+
+	if c, ok := client.(*http.Client); ok {
+		httpClient = withoutRedirects(c)
+	}
+
+	opts := twirp.DefaultClientOptions(client)
+	for _, o := range opt {
+		o(&opts)
+	}
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
 		prefix + "MakeHat",
 	}
-	if httpClient, ok := client.(*http.Client); ok {
-		return &haberdasherJSONClient{
-			client: withoutRedirects(httpClient),
-			urls:   urls,
-		}
-	}
+
 	return &haberdasherJSONClient{
-		client: client,
+		client: httpClient,
 		urls:   urls,
+		opts:   opts,
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:* #145 

*Description of changes:* This pull request makes a few changes. It modifies `twirptest/service.twirp.go` directly to explore how things could change if we were to introduce client-side hooks in a backwards compatible way. Notice how some type signatures in tests and such changed, but the underlying function calls for generating clients do not change. This is a way that Twirp can add in client-side hooks in an opt-in way and not break existing clients.
