### PR TITLE
Add optional support for memory pooling

### DIFF
--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -28,6 +28,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =====================
 // Haberdasher Interface
 // =====================
@@ -124,7 +127,9 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 
 type haberdasherServer struct {
 	Haberdasher
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewHaberdasherServer(svc Haberdasher, hooks *twirp.ServerHooks) TwirpServer {
@@ -138,6 +143,11 @@ func NewHaberdasherServer(svc Haberdasher, hooks *twirp.ServerHooks) TwirpServer
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *haberdasherServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *haberdasherServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // HaberdasherPathPrefix is used for all URL paths on a twirp Haberdasher server.
@@ -266,14 +276,22 @@ func (s *haberdasherServer) serveMakeHatProtobuf(ctx context.Context, resp http.
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Size)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Size)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -302,8 +320,11 @@ func (s *haberdasherServer) serveMakeHatProtobuf(ctx context.Context, resp http.
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -313,11 +334,12 @@ func (s *haberdasherServer) serveMakeHatProtobuf(ctx context.Context, resp http.
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -363,6 +385,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -747,6 +775,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -32,6 +32,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =============
 // Svc Interface
 // =============
@@ -126,7 +129,9 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 
 type svcServer struct {
 	Svc
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
@@ -140,6 +145,11 @@ func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svcServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
@@ -268,14 +278,22 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -304,8 +322,11 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -315,11 +336,12 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -365,6 +387,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -749,6 +777,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/google_protobuf_imports/service.twirp.go
+++ b/internal/twirptest/google_protobuf_imports/service.twirp.go
@@ -31,6 +31,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =============
 // Svc Interface
 // =============
@@ -125,7 +128,9 @@ func (c *svcJSONClient) Send(ctx context.Context, in *google_protobuf1.StringVal
 
 type svcServer struct {
 	Svc
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
@@ -139,6 +144,11 @@ func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svcServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
@@ -267,14 +277,22 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(google_protobuf1.StringValue)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(google_protobuf1.StringValue)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -303,8 +321,11 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -314,11 +335,12 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -364,6 +386,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -748,6 +776,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -31,6 +31,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =============
 // Svc Interface
 // =============
@@ -125,7 +128,9 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 
 type svcServer struct {
 	Svc
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
@@ -139,6 +144,11 @@ func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svcServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
@@ -267,14 +277,22 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -303,8 +321,11 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -314,11 +335,12 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -364,6 +386,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -748,6 +776,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -33,6 +33,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // ==============
 // Svc2 Interface
 // ==============
@@ -127,7 +130,9 @@ func (c *svc2JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_
 
 type svc2Server struct {
 	Svc2
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvc2Server(svc Svc2, hooks *twirp.ServerHooks) TwirpServer {
@@ -141,6 +146,11 @@ func NewSvc2Server(svc Svc2, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svc2Server) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svc2Server) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // Svc2PathPrefix is used for all URL paths on a twirp Svc2 server.
@@ -269,14 +279,22 @@ func (s *svc2Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(twirp_internal_twirptest_importable.Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(twirp_internal_twirptest_importable.Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -305,8 +323,11 @@ func (s *svc2Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -316,11 +337,12 @@ func (s *svc2Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -366,6 +388,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -750,6 +778,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/importmapping/x/x.twirp.go
+++ b/internal/twirptest/importmapping/x/x.twirp.go
@@ -30,6 +30,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // ==============
 // Svc1 Interface
 // ==============
@@ -124,7 +127,9 @@ func (c *svc1JSONClient) Send(ctx context.Context, in *twirp_internal_twirptest_
 
 type svc1Server struct {
 	Svc1
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvc1Server(svc Svc1, hooks *twirp.ServerHooks) TwirpServer {
@@ -138,6 +143,11 @@ func NewSvc1Server(svc Svc1, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svc1Server) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svc1Server) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // Svc1PathPrefix is used for all URL paths on a twirp Svc1 server.
@@ -266,14 +276,22 @@ func (s *svc1Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(twirp_internal_twirptest_importmapping_y.MsgY)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(twirp_internal_twirptest_importmapping_y.MsgY)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -302,8 +320,11 @@ func (s *svc1Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -313,11 +334,12 @@ func (s *svc1Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -363,6 +385,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -747,6 +775,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -32,6 +32,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // ==============
 // Svc1 Interface
 // ==============
@@ -126,7 +129,9 @@ func (c *svc1JSONClient) Send(ctx context.Context, in *Msg1) (*Msg1, error) {
 
 type svc1Server struct {
 	Svc1
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvc1Server(svc Svc1, hooks *twirp.ServerHooks) TwirpServer {
@@ -140,6 +145,11 @@ func NewSvc1Server(svc Svc1, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svc1Server) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svc1Server) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // Svc1PathPrefix is used for all URL paths on a twirp Svc1 server.
@@ -268,14 +278,22 @@ func (s *svc1Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg1)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg1)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -304,8 +322,11 @@ func (s *svc1Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -315,11 +336,12 @@ func (s *svc1Server) serveSendProtobuf(ctx context.Context, resp http.ResponseWr
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -365,6 +387,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -749,6 +777,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -28,6 +28,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =============
 // Svc Interface
 // =============
@@ -122,7 +125,9 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 
 type svcServer struct {
 	Svc
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
@@ -136,6 +141,11 @@ func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svcServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
@@ -264,14 +274,22 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -300,8 +318,11 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -311,11 +332,12 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -361,6 +383,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -745,6 +773,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -30,6 +30,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // ==============
 // Svc2 Interface
 // ==============
@@ -124,7 +127,9 @@ func (c *svc2JSONClient) Method(ctx context.Context, in *no_package_name.Msg) (*
 
 type svc2Server struct {
 	Svc2
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvc2Server(svc Svc2, hooks *twirp.ServerHooks) TwirpServer {
@@ -138,6 +143,11 @@ func NewSvc2Server(svc Svc2, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svc2Server) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svc2Server) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // Svc2PathPrefix is used for all URL paths on a twirp Svc2 server.
@@ -266,14 +276,22 @@ func (s *svc2Server) serveMethodProtobuf(ctx context.Context, resp http.Response
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(no_package_name.Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(no_package_name.Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -302,8 +320,11 @@ func (s *svc2Server) serveMethodProtobuf(ctx context.Context, resp http.Response
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -313,11 +334,12 @@ func (s *svc2Server) serveMethodProtobuf(ctx context.Context, resp http.Response
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -363,6 +385,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -747,6 +775,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -31,6 +31,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =============
 // Svc Interface
 // =============
@@ -125,7 +128,9 @@ func (c *svcJSONClient) Send(ctx context.Context, in *Msg) (*Msg, error) {
 
 type svcServer struct {
 	Svc
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
@@ -139,6 +144,11 @@ func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svcServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
@@ -267,14 +277,22 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -303,8 +321,11 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -314,11 +335,12 @@ func (s *svcServer) serveSendProtobuf(ctx context.Context, resp http.ResponseWri
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -364,6 +386,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -748,6 +776,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -28,6 +28,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =====================
 // Haberdasher Interface
 // =====================
@@ -124,7 +127,9 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 
 type haberdasherServer struct {
 	Haberdasher
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewHaberdasherServer(svc Haberdasher, hooks *twirp.ServerHooks) TwirpServer {
@@ -138,6 +143,11 @@ func NewHaberdasherServer(svc Haberdasher, hooks *twirp.ServerHooks) TwirpServer
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *haberdasherServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *haberdasherServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // HaberdasherPathPrefix is used for all URL paths on a twirp Haberdasher server.
@@ -266,14 +276,22 @@ func (s *haberdasherServer) serveMakeHatProtobuf(ctx context.Context, resp http.
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Size)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Size)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -302,8 +320,11 @@ func (s *haberdasherServer) serveMakeHatProtobuf(ctx context.Context, resp http.
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -313,11 +334,12 @@ func (s *haberdasherServer) serveMakeHatProtobuf(ctx context.Context, resp http.
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -363,6 +385,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -747,6 +775,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
+++ b/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
@@ -28,6 +28,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // ==============
 // Echo Interface
 // ==============
@@ -122,7 +125,9 @@ func (c *echoJSONClient) Echo(ctx context.Context, in *Msg) (*Msg, error) {
 
 type echoServer struct {
 	Echo
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewEchoServer(svc Echo, hooks *twirp.ServerHooks) TwirpServer {
@@ -136,6 +141,11 @@ func NewEchoServer(svc Echo, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *echoServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *echoServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // EchoPathPrefix is used for all URL paths on a twirp Echo server.
@@ -264,14 +274,22 @@ func (s *echoServer) serveEchoProtobuf(ctx context.Context, resp http.ResponseWr
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -300,8 +318,11 @@ func (s *echoServer) serveEchoProtobuf(ctx context.Context, resp http.ResponseWr
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -311,11 +332,12 @@ func (s *echoServer) serveEchoProtobuf(ctx context.Context, resp http.ResponseWr
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -361,6 +383,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -745,6 +773,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{

--- a/internal/twirptest/source_relative/source_relative.twirp.go
+++ b/internal/twirptest/source_relative/source_relative.twirp.go
@@ -28,6 +28,9 @@ import strconv "strconv"
 import json "encoding/json"
 import url "net/url"
 
+// Reference imports to suppress errors if they are not otherwise used.
+var _ = ioutil.ReadAll
+
 // =============
 // Svc Interface
 // =============
@@ -122,7 +125,9 @@ func (c *svcJSONClient) Method(ctx context.Context, in *Msg) (*Msg, error) {
 
 type svcServer struct {
 	Svc
-	hooks *twirp.ServerHooks
+	hooks    *twirp.ServerHooks
+	reqPool  BufferPool
+	respPool BufferPool
 }
 
 func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
@@ -136,6 +141,11 @@ func NewSvcServer(svc Svc, hooks *twirp.ServerHooks) TwirpServer {
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
 func (s *svcServer) writeError(ctx context.Context, resp http.ResponseWriter, err error) {
 	writeError(ctx, resp, err, s.hooks)
+}
+
+func (s *svcServer) SetBufferPools(reqPool, respPool BufferPool) {
+	s.reqPool = reqPool
+	s.respPool = respPool
 }
 
 // SvcPathPrefix is used for all URL paths on a twirp Svc server.
@@ -264,14 +274,22 @@ func (s *svcServer) serveMethodProtobuf(ctx context.Context, resp http.ResponseW
 		return
 	}
 
-	buf, err := ioutil.ReadAll(req.Body)
+	reqContent := new(Msg)
+	var rbuf *bytes.Buffer
+	if b := getbuf(s.reqPool); b != nil {
+		rbuf = bytes.NewBuffer(b)
+	} else {
+		rbuf = new(bytes.Buffer)
+	}
+	_, err = rbuf.ReadFrom(req.Body)
 	if err != nil {
 		err = wrapErr(err, "failed to read request body")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
 	}
-	reqContent := new(Msg)
-	if err = proto.Unmarshal(buf, reqContent); err != nil {
+	err = proto.Unmarshal(rbuf.Bytes(), reqContent)
+	putbuf(s.reqPool, rbuf.Bytes())
+	if err != nil {
 		err = wrapErr(err, "failed to parse request proto")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
 		return
@@ -300,8 +318,11 @@ func (s *svcServer) serveMethodProtobuf(ctx context.Context, resp http.ResponseW
 	}
 
 	ctx = callResponsePrepared(ctx, s.hooks)
-
-	respBytes, err := proto.Marshal(respContent)
+	var wbuf proto.Buffer
+	if b := getbuf(s.respPool); b != nil {
+		wbuf.SetBuf(b)
+	}
+	err = wbuf.Marshal(respContent)
 	if err != nil {
 		err = wrapErr(err, "failed to marshal proto response")
 		s.writeError(ctx, resp, twirp.InternalErrorWith(err))
@@ -311,11 +332,12 @@ func (s *svcServer) serveMethodProtobuf(ctx context.Context, resp http.ResponseW
 	ctx = ctxsetters.WithStatusCode(ctx, http.StatusOK)
 	resp.Header().Set("Content-Type", "application/protobuf")
 	resp.WriteHeader(http.StatusOK)
-	if n, err := resp.Write(respBytes); err != nil {
-		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(respBytes), err.Error())
+	if n, err := resp.Write(wbuf.Bytes()); err != nil {
+		msg := fmt.Sprintf("failed to write response, %d of %d bytes written: %s", n, len(wbuf.Bytes()), err.Error())
 		twerr := twirp.NewError(twirp.Unknown, msg)
 		callError(ctx, s.hooks, twerr)
 	}
+	putbuf(s.respPool, wbuf.Bytes())
 	callResponseSent(ctx, s.hooks)
 }
 
@@ -361,6 +383,12 @@ type TwirpServer interface {
 	// ProtocGenTwirpVersion is the semantic version string of the version of
 	// twirp used to generate this file.
 	ProtocGenTwirpVersion() string
+	// SetBuferPools sets the optional memory pools that will be used to serialize
+	// and deserialize ProtoBuf messages. The same pool object may be set for both
+	// deserialization (requests) and serialization (responses), or different pools
+	// may be used if the average size for incoming requests vastly differs from the
+	// average size for responses.
+	SetBufferPools(req BufferPool, resp BufferPool)
 }
 
 // WriteError writes an HTTP response with a valid Twirp error format.
@@ -745,6 +773,30 @@ func callError(ctx context.Context, h *twirp.ServerHooks, err twirp.Error) conte
 		return ctx
 	}
 	return h.Error(ctx, err)
+}
+
+// BufferPool represents a pool of buffers. The *sync.Pool type satisfies this
+// interface.  The type of the value stored in a pool is not specified.
+type BufferPool interface {
+	// Get gets a value from the pool or returns nil if the pool is empty.
+	Get() interface{}
+	// Put adds a value to the pool.
+	Put(x interface{})
+}
+
+func getbuf(pool BufferPool) []byte {
+	if pool != nil {
+		if b := pool.Get(); b != nil {
+			return b.([]byte)
+		}
+	}
+	return nil
+}
+
+func putbuf(pool BufferPool, b []byte) {
+	if pool != nil {
+		pool.Put(b[:0])
+	}
 }
 
 var twirpFileDescriptor0 = []byte{


### PR DESCRIPTION
Hi all!! So we've been working on a Twirp service here at GitHub that handles pretty large ProtoBuf payloads and we found that (de)serialization can get a bit slow -- at least slow enough to show up in the profiles, which is never a good thing!

I wanted to improve this situation, but I know that you folks really care about backwards compatibility, so this is a bit of a restrained PR (no user-facing changes, no breaking changes at all and disabled by default) that enables memory pooling for the temporary buffers used to (de)serialize requests and responses.

I think the code is quite non-intrusive and the benchmark results are very significant considering the constraints, so overall I'm quite happy with the result. I would love to hear if you have any ideas to make this even less intrusive and easier to land on master.

Commit message inline for your convenience:

```
Because of the way the ProtoBuf APIs have been designed, wherein
serialization and de-serialization of messages must be performed on a
full byte slice (i.e. incremental (de)serialization is not possible),
the current version of Twirp's codegen allocates a lot of temporary
memory for each request:

- A full `bytes.Buffer` is allocated when reading the message by
`ioutil.ReadAll`. The backing slice for this buffer has a minimum size
of 512 bytes, even for small messages, because of the minimum read-size
in the stdandard library.

- A byte slice with approximately the same size as the generated
ProtoBuf response, allocated as part of `proto.Marshal`.

Both these memory allocations are used as scratch buffers, independently
of the allocation sizes for the generated ProtoBuf request and response
objects.

We have found that these memory allocations are significant enough to
show up when profiling Twirp services that deal with large or complex
ProtoBuf schemas, in either request or response form. Since scratch
buffers will always be required to parse and serialize ProtoBuf objects
in Go, this commit attempts to minimize the impact of the buffers by
using a memory pool to re-use them between requests.

These memory pools have been implemented in a backwards-compatible way
in the `serveXXXProtobuf` methods, and are disabled by default. An user
of the generated Twirp code may call `SetBufferPools` in the generated
server instance to set the memory pool objects that will be used to
serialize requests and responses; a different pool may be set for
request and for response buffers, or pooling may be disabled for either.

A new interface, `BufferPool` has been provided as part of the codegen
code. This is the interface that the memory pools must fulfill. The
standard library's `sync.Pool` fulfills this interface, so it's
straightforward to simply pass a `Pool` when configuring pooling, but
more advanced users may want to implement more complex logic for memory
pooling and/or eviction.

Because serialization and de-serialization in ProtoBuf use different
APIs, the actual implementations for each case have been slightly
modified so they can be consistently abstracted using the same memory
pool and so the functionality is equivalent to the existing code when
Pooling is disabled.

- For de-serialization, we need to read the whole contents of an
`io.Reader` into a byte slice. The old version of the code used
`ioutil.ReadAll`, which allocates a `bytes.Buffer` behind the scenes.
For this new version, we explicitly create an empty `bytes.Buffer` when
pooling is disabled and call `ReadFrom` on it, so this is functionally
equivalent to how de-serialization worked before the commit. When
pooling is enabled, we also create a `bytes.Buffer`, but we set the
backing slice to a pooled zero-size byte slice. This will prevent
`ReadFrom` from growing the backing slice as long as the pooled instance
has capacity. If the pooled instance does not have enough capacity, it
will be grown and cleaned up by the GC, and we will return the newly
allocated backing slice to the pool.

- For serialization, we do not call `proto.Marshal` directly in
any case, because this API will always allocate a new buffer. Instead,
we stack allocate a `proto.Buffer`. This struct is provided by the
stable proto API and allows us to use its `Marshal` method to serialize
an object directly into it. This is functionally equivalent to
`proto.Marshal` for the unpooled case, but when pooling is enabled, we
can replace the backing slice of the buffer with a byte slice from the
buffer pool. The same semantics as de-serialization apply here: as long
as there's capacity in the backing slice it won't be expanded, greatly
reducing the average allocation size.

It is worth noting that both (de)serialization cases have also been
carefully designed to trigger the most efficient code when your ProtoBuf
schemas have been generated using the alternative Gogo ProtoBuf
compiler.

To verify the impact of these optimizations, a set of benchmarks has
been designed where an Echo Twirp server processes complex ProtoBuf
messages. For this case, `Bench1` is a complex multi-field message from
Google's ProtoBuf benchmark suite, and `Bench2` is a large-size message
taken from one of GitHub's internal services.

Each message type is benchmarked using the default ProtoBuf
(de)serialization code and the Gogo ProtoBuf codegen. The results are as
follows (old is the old Twirp codgen; new is the codegen with pooling
enabled):

benchmark                  old ns/op     new ns/op     delta
BenchmarkBench1-16         10030         8126          -18.98%
BenchmarkBench1Gogo-16     7954          5324          -33.07%
BenchmarkBench2-16         5598061       4093236       -26.88%
BenchmarkBench2Gogo-16     2989519       1905072       -36.27%

benchmark                  old allocs     new allocs     delta
BenchmarkBench1-16         35             34             -2.86%
BenchmarkBench1Gogo-16     36             34             -5.56%
BenchmarkBench2-16         169            158            -6.51%
BenchmarkBench2Gogo-16     169            158            -6.51%

benchmark                  old bytes     new bytes     delta
BenchmarkBench1-16         5264          2386          -54.67%
BenchmarkBench1Gogo-16     9840          2610          -73.48%
BenchmarkBench2-16         8492147       2192365       -74.18%
BenchmarkBench2Gogo-16     8492152       2142307       -74.77%

To note: although the results are very significant for both message
types, using the Gogo ProtoBuf (de)serializer with memory pooling
provides the greatest gains. In any case, the benefit of enabling memory
pooling is always greater than the benefit of switching to Gogo
ProtoBuf, and using both always compounds.
```