### PR TITLE
Add Go Modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ go:
 - 1.11.x
 - 1.12.x
 - tip
-environment:
-  - GO111MODULE=on
+env:	
+  global:
+    - GO111MODULE=on
 script:
 - go install ./...
 - go test -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: false
 language: go
 go:
-- 1.9.x
-- 1.10.x
 - 1.11.x
+- 1.12.x
 - tip
+environment:
+  - GO111MODULE=on
 script:
 - go install ./...
 - go test -race ./...

--- a/clientcompat/clientcompat.go
+++ b/clientcompat/clientcompat.go
@@ -16,7 +16,7 @@ package main
 import (
 	"context"
 
-	"github.com/twitchtv/twirp/clientcompat/internal/clientcompat"
+	"github.com/twitchtv/twirp/v6/clientcompat/internal/clientcompat"
 )
 
 type clientCompat struct {

--- a/clientcompat/gocompat/gocompat.go
+++ b/clientcompat/gocompat/gocompat.go
@@ -21,8 +21,8 @@ import (
 	"os"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/twitchtv/twirp"
-	"github.com/twitchtv/twirp/clientcompat/internal/clientcompat"
+	"github.com/twitchtv/twirp/v6"
+	"github.com/twitchtv/twirp/v6/clientcompat/internal/clientcompat"
 )
 
 func main() {

--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/clientcompat/main.go
+++ b/clientcompat/main.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/twitchtv/twirp"
-	"github.com/twitchtv/twirp/clientcompat/internal/clientcompat"
+	"github.com/twitchtv/twirp/v6"
+	"github.com/twitchtv/twirp/v6/clientcompat/internal/clientcompat"
 )
 
 var (

--- a/clientcompat/run.go
+++ b/clientcompat/run.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
-	"github.com/twitchtv/twirp/clientcompat/internal/clientcompat"
+	"github.com/twitchtv/twirp/v6/clientcompat/internal/clientcompat"
 )
 
 func runClient(clientBin string, msg *clientcompat.ClientCompatMessage) (resp []byte, errCode string, err error) {

--- a/context.go
+++ b/context.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/twitchtv/twirp/internal/contextkeys"
+	"github.com/twitchtv/twirp/v6/internal/contextkeys"
 )
 
 // MethodName extracts the name of the method being handled in the given

--- a/ctxsetters/ctxsetters.go
+++ b/ctxsetters/ctxsetters.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/twitchtv/twirp/internal/contextkeys"
+	"github.com/twitchtv/twirp/v6/internal/contextkeys"
 )
 
 func WithMethodName(ctx context.Context, name string) context.Context {

--- a/example/cmd/client/main.go
+++ b/example/cmd/client/main.go
@@ -19,8 +19,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/twitchtv/twirp"
-	"github.com/twitchtv/twirp/example"
+	"github.com/twitchtv/twirp/v6"
+	"github.com/twitchtv/twirp/v6/example"
 )
 
 func main() {

--- a/example/cmd/server/main.go
+++ b/example/cmd/server/main.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/twitchtv/twirp"
-	"github.com/twitchtv/twirp/example"
-	"github.com/twitchtv/twirp/hooks/statsd"
+	"github.com/twitchtv/twirp/v6"
+	"github.com/twitchtv/twirp/v6/example"
+	"github.com/twitchtv/twirp/v6/hooks/statsd"
 )
 
 type randomHaberdasher struct{}

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/twitchtv/twirp
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415
+	github.com/golang/protobuf v0.0.0-20180919224659-7716a980bcee
+	github.com/pkg/errors v0.8.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.2.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/twitchtv/twirp
+module github.com/twitchtv/twirp/v6
 
 go 1.12
 
@@ -9,4 +9,5 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.2.0
+	github.com/twitchtv/twirp v5.6.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 h1:WSBJMqJbLxsn+bTCPyPYZfqHdJmc8MK4wrBjMft6BAM=
+github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/protobuf v0.0.0-20180919224659-7716a980bcee h1:5o3oVO7Gbd1wjnF3FTXCai8v+szwN6Jme/Er6tD7UyU=
+github.com/golang/protobuf v0.0.0-20180919224659-7716a980bcee/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 h1:WSBJMqJbLxsn+bTCPyPYZfqHdJmc8MK4wrBjMft6BAM=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -5,8 +6,12 @@ github.com/golang/protobuf v0.0.0-20180919224659-7716a980bcee h1:5o3oVO7Gbd1wjnF
 github.com/golang/protobuf v0.0.0-20180919224659-7716a980bcee/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.0 h1:LThGCOvhuJic9Gyd1VBCkhyUXmO8vKaBFvBsJ2k03rg=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/twitchtv/twirp v5.6.0+incompatible h1:sUqlJqdfCAIPDShsmjo3Gixzccs1KWCtFctfpNYcnPE=
+github.com/twitchtv/twirp v5.6.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/hooks/statsd/statsd.go
+++ b/hooks/statsd/statsd.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/twitchtv/twirp"
+	"github.com/twitchtv/twirp/v6"
 )
 
 var reqStartTimestampKey = new(int)

--- a/hooks/statsd/statsd_test.go
+++ b/hooks/statsd/statsd_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/twitchtv/twirp"
-	"github.com/twitchtv/twirp/internal/twirptest"
+	"github.com/twitchtv/twirp/v6"
+	"github.com/twitchtv/twirp/v6/internal/twirptest"
 )
 
 func TestSanitize(t *testing.T) {

--- a/internal/gen/wrappers.go
+++ b/internal/gen/wrappers.go
@@ -53,7 +53,7 @@ import (
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/twitchtv/twirp/internal/gen/stringutils"
+	"github.com/twitchtv/twirp/v6/internal/gen/stringutils"
 )
 
 // Each type we import as a protocol buffer (other than FileDescriptorProto) needs
@@ -414,8 +414,8 @@ func wrapServices(file *descriptor.FileDescriptorProto) (sl []*ServiceDescriptor
 		sd := &ServiceDescriptor{
 			common:                 common{file},
 			ServiceDescriptorProto: svc,
-			Index: i,
-			Path:  fmt.Sprintf("%d,%d", servicePath, i),
+			Index:                  i,
+			Path:                   fmt.Sprintf("%d,%d", servicePath, i),
 		}
 		for j, method := range svc.Method {
 			md := &MethodDescriptor{

--- a/internal/twirptest/client_test.go
+++ b/internal/twirptest/client_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/twitchtv/twirp"
+	"github.com/twitchtv/twirp/v6"
 )
 
 // reqInspector is a tool to check inspect HTTP Requests as they pass

--- a/internal/twirptest/gogo_compat/gogo_compat_test.go
+++ b/internal/twirptest/gogo_compat/gogo_compat_test.go
@@ -16,7 +16,7 @@ package gogo_compat
 import (
 	"testing"
 
-	"github.com/twitchtv/twirp/internal/descriptors"
+	"github.com/twitchtv/twirp/v6/internal/descriptors"
 )
 
 func TestCompilation(t *testing.T) {

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -23,8 +23,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/google_protobuf_imports/service.twirp.go
+++ b/internal/twirptest/google_protobuf_imports/service.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 import google_protobuf1 "github.com/golang/protobuf/ptypes/wrappers"
 import google_protobuf "github.com/golang/protobuf/ptypes/empty"

--- a/internal/twirptest/hatmakers.go
+++ b/internal/twirptest/hatmakers.go
@@ -19,7 +19,7 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/twitchtv/twirp"
+	"github.com/twitchtv/twirp/v6"
 )
 
 type hatmaker func(ctx context.Context, s *Size) (*Hat, error)

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -22,8 +22,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/importer/importer.pb.go
+++ b/internal/twirptest/importer/importer.pb.go
@@ -8,7 +8,7 @@ package importer
 import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
-	_ "github.com/twitchtv/twirp/internal/twirptest/importable"
+	_ "github.com/twitchtv/twirp/v6/internal/twirptest/importable"
 	math "math"
 )
 

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -22,10 +22,10 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
-import twirp_internal_twirptest_importable "github.com/twitchtv/twirp/internal/twirptest/importable"
+import twirp_internal_twirptest_importable "github.com/twitchtv/twirp/v6/internal/twirptest/importable"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/importmapping/x/x.pb.go
+++ b/internal/twirptest/importmapping/x/x.pb.go
@@ -6,7 +6,7 @@ package x
 import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
-	_ "github.com/twitchtv/twirp/internal/twirptest/importmapping/y"
+	_ "github.com/twitchtv/twirp/v6/internal/twirptest/importmapping/y"
 	math "math"
 )
 

--- a/internal/twirptest/importmapping/x/x.twirp.go
+++ b/internal/twirptest/importmapping/x/x.twirp.go
@@ -19,10 +19,10 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
-import twirp_internal_twirptest_importmapping_y "github.com/twitchtv/twirp/internal/twirptest/importmapping/y"
+import twirp_internal_twirptest_importmapping_y "github.com/twitchtv/twirp/v6/internal/twirptest/importmapping/y"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -23,8 +23,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -12,8 +12,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // ==============
 // Svc2 Interface

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.pb.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.pb.go
@@ -6,7 +6,7 @@ package no_package_name_importer
 import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
-	_ "github.com/twitchtv/twirp/internal/twirptest/no_package_name"
+	_ "github.com/twitchtv/twirp/v6/internal/twirptest/no_package_name"
 	math "math"
 )
 

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -19,10 +19,10 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
-import no_package_name "github.com/twitchtv/twirp/internal/twirptest/no_package_name"
+import no_package_name "github.com/twitchtv/twirp/v6/internal/twirptest/no_package_name"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -22,8 +22,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
+++ b/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/service_test.go
+++ b/internal/twirptest/service_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	pkgerrors "github.com/pkg/errors"
 
-	"github.com/twitchtv/twirp"
-	"github.com/twitchtv/twirp/internal/descriptors"
+	"github.com/twitchtv/twirp/v6"
+	"github.com/twitchtv/twirp/v6/internal/descriptors"
 )
 
 func TestServeJSON(t *testing.T) {

--- a/internal/twirptest/snake_case_names/snake_case_names.twirp.go
+++ b/internal/twirptest/snake_case_names/snake_case_names.twirp.go
@@ -23,8 +23,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/internal/twirptest/source_relative/source_relative.twirp.go
+++ b/internal/twirptest/source_relative/source_relative.twirp.go
@@ -19,8 +19,8 @@ import http "net/http"
 
 import jsonpb "github.com/golang/protobuf/jsonpb"
 import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+import twirp "github.com/twitchtv/twirp/v6"
+import ctxsetters "github.com/twitchtv/twirp/v6/ctxsetters"
 
 // Imports only used by utility functions:
 import io "io"

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -29,9 +29,9 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/pkg/errors"
-	"github.com/twitchtv/twirp/internal/gen"
-	"github.com/twitchtv/twirp/internal/gen/stringutils"
-	"github.com/twitchtv/twirp/internal/gen/typemap"
+	"github.com/twitchtv/twirp/v6/internal/gen"
+	"github.com/twitchtv/twirp/v6/internal/gen/stringutils"
+	"github.com/twitchtv/twirp/v6/internal/gen/typemap"
 )
 
 type twirp struct {
@@ -265,8 +265,8 @@ func (t *twirp) generateImports(file *descriptor.FileDescriptorProto) {
 	t.P()
 	t.P(`import `, t.pkgs["jsonpb"], ` "github.com/golang/protobuf/jsonpb"`)
 	t.P(`import `, t.pkgs["proto"], ` "github.com/golang/protobuf/proto"`)
-	t.P(`import `, t.pkgs["twirp"], ` "github.com/twitchtv/twirp"`)
-	t.P(`import `, t.pkgs["ctxsetters"], ` "github.com/twitchtv/twirp/ctxsetters"`)
+	t.P(`import `, t.pkgs["twirp"], ` "github.com/twitchtv/twirp/v6"`)
+	t.P(`import `, t.pkgs["ctxsetters"], ` "github.com/twitchtv/twirp/v6/ctxsetters"`)
 	t.P()
 
 	// It's legal to import a message and use it as an input or output for a

--- a/protoc-gen-twirp/go_naming.go
+++ b/protoc-gen-twirp/go_naming.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/twitchtv/twirp/internal/gen/stringutils"
+	"github.com/twitchtv/twirp/v6/internal/gen/stringutils"
 )
 
 // goPackageOption interprets the file's go_package option.

--- a/protoc-gen-twirp/main.go
+++ b/protoc-gen-twirp/main.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/twitchtv/twirp/internal/gen"
+	"github.com/twitchtv/twirp/v6/internal/gen"
 )
 
 func main() {

--- a/protoc-gen-twirp_python/main.go
+++ b/protoc-gen-twirp_python/main.go
@@ -25,9 +25,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
-	"github.com/twitchtv/twirp/internal/gen"
-	"github.com/twitchtv/twirp/internal/gen/stringutils"
-	"github.com/twitchtv/twirp/internal/gen/typemap"
+	"github.com/twitchtv/twirp/v6/internal/gen"
+	"github.com/twitchtv/twirp/v6/internal/gen/stringutils"
+	"github.com/twitchtv/twirp/v6/internal/gen/typemap"
 )
 
 func main() {


### PR DESCRIPTION
This PR demonstrates support for Go Modules. It doesn't have to be merged as it just shows a working version of twirp with modules. Although it can be merged if the maintainers are comfortable with the change :) 

The versions in the `go.mod` file were generated based on the existent Gopkg.toml file. In particular, the gogo/protobuf package seems quite outdated. 

Adding support for Go Modules for programs that are tagged > 1 are considered backwards incompatible and therefore they require a new version upgrade. Quite unfortunate to introduce a whole new version just because you have module support, but at the same time it ensures that people living in the old world can still function correctly by just using the previous major version. 

I have not deleted the vendor folder nor the *.toml files as they would make this PR look too scary. 

Updates https://github.com/twitchtv/twirp/issues/169