### PR TITLE
Add SetHTTPCookie

### DIFF
--- a/context.go
+++ b/context.go
@@ -123,3 +123,12 @@ func SetHTTPResponseHeader(ctx context.Context, key, value string) error {
 
 	return nil
 }
+
+// SetHTTPCookie adds a Set-Cookie header using a context provided by
+// a twirp-generated server, or a child of that context.
+func SetHTTPCookie(ctx context.Context, cookie *http.Cookie) {
+	responseWriter, ok := ctx.Value(contextkeys.ResponseWriterKey).(http.ResponseWriter)
+	if ok {
+		http.SetCookie(responseWriter, cookie)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
#176 

*Description of changes:*
`SetHTTPResponseHeader` lacks the ability to add multiple headers with the same key. 
Headers with the same key is often for `Set-Cookie` header. Adding `SetHTTPCookie` function that invokes `http.SetCookie`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
