### PR TITLE
Fix use of rand.Intn

### DIFF
--- a/example/cmd/server/main.go
+++ b/example/cmd/server/main.go
@@ -33,7 +33,7 @@ func (h *randomHaberdasher) MakeHat(ctx context.Context, size *example.Size) (*e
 	}
 	colors := []string{"white", "black", "brown", "red", "blue"}
 	names := []string{"bowler", "baseball cap", "top hat", "derby"}
-	return &haberdasher.Hat{
+	return &example.Hat{
 		Size:  size.Inches,
 		Color: colors[rand.Intn(len(colors))],
 		Name:  names[rand.Intn(len(names))],

--- a/example/cmd/server/main.go
+++ b/example/cmd/server/main.go
@@ -31,10 +31,12 @@ func (h *randomHaberdasher) MakeHat(ctx context.Context, size *example.Size) (*e
 	if size.Inches <= 0 {
 		return nil, twirp.InvalidArgumentError("Inches", "I can't make a hat that small!")
 	}
-	return &example.Hat{
+	colors := []string{"white", "black", "brown", "red", "blue"}
+	names := []string{"bowler", "baseball cap", "top hat", "derby"}
+	return &haberdasher.Hat{
 		Size:  size.Inches,
-		Color: []string{"white", "black", "brown", "red", "blue"}[rand.Intn(4)],
-		Name:  []string{"bowler", "baseball cap", "top hat", "derby"}[rand.Intn(3)],
+		Color: colors[rand.Intn(len(colors))],
+		Name:  names[rand.Intn(len(names))],
 	}, nil
 }
 


### PR DESCRIPTION
The example uses rand.Intn(4) on a slice of len 5, meaning the last element (e.g. "blue") can never be returned. rand.Intn should be called with the len of the slice.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
