### PR TITLE
hooks/statsd: update statsd docs to reflect current state of code

### DIFF
--- a/hooks/statsd/statsd.go
+++ b/hooks/statsd/statsd.go
@@ -61,12 +61,12 @@ func NewStatsdServerHooks(stats Statter) *twirp.ServerHooks {
 	// ResponseSent:
 	// - inc twirp.total.response
 	// - inc twirp.<method>.response
-	// - inc twirp.by_code.total.<code>.response
-	// - inc twirp.by_code.<method>.<code>.response
+	// - inc twirp.status_codes.total.<code>.response
+	// - inc twirp.status_codes.<method>.<code>.response
 	// - time twirp.total.response
 	// - time twirp.<method>.response
-	// - time twirp.by_code.total.<code>.response
-	// - time twirp.by_code.<method>.<code>.response
+	// - time twirp.status_codes.total.<code>.response
+	// - time twirp.status_codes.<method>.<code>.response
 	hooks.ResponseSent = func(ctx context.Context) {
 		// Three pieces of data to get, none are guaranteed to be present:
 		// - time that the request started

--- a/hooks/statsd/statsd.go
+++ b/hooks/statsd/statsd.go
@@ -59,14 +59,14 @@ func NewStatsdServerHooks(stats Statter) *twirp.ServerHooks {
 	}
 
 	// ResponseSent:
-	// - inc twirp.total.response
-	// - inc twirp.<method>.response
-	// - inc twirp.status_codes.total.<code>.response
-	// - inc twirp.status_codes.<method>.<code>.response
-	// - time twirp.total.response
+	// - inc twirp.total.responses
+	// - inc twirp.<method>.responses
+	// - inc twirp.status_codes.total.<code>
+	// - inc twirp.status_codes.<method>.<code>
+	// - time twirp.all_methods.response
 	// - time twirp.<method>.response
-	// - time twirp.status_codes.total.<code>.response
-	// - time twirp.status_codes.<method>.<code>.response
+	// - time twirp.status_codes.all_methods.<code>
+	// - time twirp.status_codes.<method>.<code>
 	hooks.ResponseSent = func(ctx context.Context) {
 		// Three pieces of data to get, none are guaranteed to be present:
 		// - time that the request started


### PR DESCRIPTION
The comment outlining the statsd metrics emitted by twirp uses 'by_code'
The actual metrics sent use 'status_codes' in place of 'by_code'.

This commit resolves that discrepancy.

Fixes #190 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
