### PR TITLE
Adds WriteError func for writing Twirp errors to http.ResponseWriter

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -121,3 +121,24 @@ If your service requires errors with complex metadata, you should consider addin
 wrappers on top of the auto-generated clients, or just include business-logic errors as
 part of the Protobuf messages (add an error field to proto messages).
 
+### Writing HTTP Errors outside Twirp services
+
+Twirp services can be [muxed with other HTTP services](mux.md). For consistent responses 
+and error codes _outside_ Twirp servers, such as http middlewares, you can call `twirp.WriteError`. 
+
+The error is expected to satisfy a `twirp.Error`, otherwise it is wrapped with `twirp.InternalError`.
+
+Usage:
+
+```go
+rpc.WriteError(w, twirp.NewError(twirp.Unauthenticated, "invalid token"))
+```
+
+To simplify `twirp.Error` composition, a few constructors are available, such as `NotFoundError` 
+and `RequiredArgumentError`. See [docs](https://godoc.org/github.com/twitchtv/twirp#Error).
+
+With constructor:
+
+```go
+rpc.WriteError(w, twirp.RequiredArgumentError("user_id"))
+```

--- a/errors.go
+++ b/errors.go
@@ -41,7 +41,12 @@
 //
 package twirp
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
 
 // Error represents an error in a Twirp service call.
 type Error interface {
@@ -346,3 +351,70 @@ func (e *wrappedErr) WithMeta(key string, val string) Error {
 	}
 }
 func (e *wrappedErr) Cause() error { return e.cause }
+
+// WriteError writes an HTTP response with a valid Twirp error format (code, msg, meta).
+// Useful outside of the Twirp server (e.g. http middleware).
+// If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
+func WriteError(resp http.ResponseWriter, err error) {
+	writeError(resp, err)
+}
+
+// writeError writes Twirp errors in the response.
+func writeError(resp http.ResponseWriter, err error) {
+	// Non-twirp errors are wrapped as Internal (default)
+	twerr, ok := err.(Error)
+	if !ok {
+		twerr = InternalErrorWith(err)
+	}
+
+	statusCode := ServerHTTPStatusFromErrorCode(twerr.Code())
+	respBody := marshalErrorToJSON(twerr)
+
+	resp.Header().Set("Content-Type", "application/json") // Error responses are always JSON
+	resp.Header().Set("Content-Length", strconv.Itoa(len(respBody)))
+	resp.WriteHeader(statusCode) // set HTTP status code and send response
+
+	_, writeErr := resp.Write(respBody)
+	if writeErr != nil {
+		// We have two options here. We could log the error, or just silently
+		// ignore the error.
+		//
+		// Logging is unacceptable because we don't have a user-controlled
+		// logger; writing out to stderr without permission is too rude.
+		//
+		// Silently ignoring the error is our least-bad option. It's highly
+		// likely that the connection is broken and the original 'err' says
+		// so anyway.
+		_ = writeErr
+	}
+}
+
+// JSON serialization for errors
+type twerrJSON struct {
+	Code string            `json:"code"`
+	Msg  string            `json:"msg"`
+	Meta map[string]string `json:"meta,omitempty"`
+}
+
+// marshalErrorToJSON returns JSON from a twirp.Error, that can be used as HTTP error response body.
+// If serialization fails, it will use a descriptive Internal error instead.
+func marshalErrorToJSON(twerr Error) []byte {
+	// make sure that msg is not too large
+	msg := twerr.Msg()
+	if len(msg) > 1e6 {
+		msg = msg[:1e6]
+	}
+
+	tj := twerrJSON{
+		Code: string(twerr.Code()),
+		Msg:  msg,
+		Meta: twerr.MetaMap(),
+	}
+
+	buf, err := json.Marshal(&tj)
+	if err != nil {
+		buf = []byte("{\"type\": \"" + Internal + "\", \"msg\": \"There was an error but it could not be serialized into JSON\"}") // fallback
+	}
+
+	return buf
+}


### PR DESCRIPTION
Fixes #186 #161 

This changeset copies the twirp service implementation of `WriteError` to the core `twitchtv/twirp` package. 

Note, all mention of "hooks" and underlying use of context has been removed. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.