### PR TITLE
[DO NOT MERGE] RFC: Client hooks redux

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the License is
+// located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+package twirp
+
+import (
+	"context"
+	"net/http"
+)
+
+// HTTPClient is the interface used by generated clients to send HTTP requests.
+// It is fulfilled by *(net/http).Client, which is sufficient for most users.
+// Users can provide their own implementation for special retry policies.
+//
+// HTTPClient implementations should not follow redirects. Redirects are
+// automatically disabled if *(net/http).Client is passed to client
+// constructors. See the withoutRedirects function in this file for more
+// details.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type ClientOption func(*ClientOptions)
+
+type ClientOptions struct {
+	Client HTTPClient
+	Hooks  *ClientHooks
+}
+
+type ClientHooks struct {
+	// RequestPrepared is called as soon as a request has been created and before it has been sent
+	// to the Twirp server.
+	RequestPrepared func(context.Context, *http.Request) (context.Context, error)
+
+	// RequestFinished (alternatively could be named ResponseReceived and take in some response from
+	// the server as well) is called after a request has finished sending. Since this is terminal, the context is
+	// not returned.
+	RequestFinished func(context.Context)
+
+	// Error hook is called whenever an error occurs during the sending of a request. The Error is passed
+	// as an argument to the hook.
+	Error func(context.Context, Error) context.Context
+}
+
+func DefaultClientOptions(client HTTPClient) ClientOptions {
+	return ClientOptions{
+		Client: client,
+		Hooks:  nil,
+	}
+}
+
+func WithClientHooks(hooks *ClientHooks) ClientOption {
+	return func(o *ClientOptions) {
+		o.Hooks = hooks
+	}
+}

--- a/client.go
+++ b/client.go
@@ -17,23 +17,10 @@ import (
 	"net/http"
 )
 
-// HTTPClient is the interface used by generated clients to send HTTP requests.
-// It is fulfilled by *(net/http).Client, which is sufficient for most users.
-// Users can provide their own implementation for special retry policies.
-//
-// HTTPClient implementations should not follow redirects. Redirects are
-// automatically disabled if *(net/http).Client is passed to client
-// constructors. See the withoutRedirects function in this file for more
-// details.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 type ClientOption func(*ClientOptions)
 
 type ClientOptions struct {
-	Client HTTPClient
-	Hooks  *ClientHooks
+	Hooks *ClientHooks
 }
 
 type ClientHooks struct {
@@ -51,10 +38,9 @@ type ClientHooks struct {
 	Error func(context.Context, Error) context.Context
 }
 
-func DefaultClientOptions(client HTTPClient) ClientOptions {
+func DefaultClientOptions() ClientOptions {
 	return ClientOptions{
-		Client: client,
-		Hooks:  nil,
+		Hooks: nil,
 	}
 }
 

--- a/internal/twirptest/client_test.go
+++ b/internal/twirptest/client_test.go
@@ -201,7 +201,7 @@ func TestClientSetsAcceptHeader(t *testing.T) {
 
 // If a server returns a 3xx response, give a clear error message
 func TestClientRedirectError(t *testing.T) {
-	testcase := func(code int, clientMaker func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
+	testcase := func(code int, clientMaker func(string, HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
 		return func(t *testing.T) {
 			// Make a server that redirects all requests
 			redirecter := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +258,7 @@ func TestClientRedirectError(t *testing.T) {
 }
 
 func TestClientIntermediaryErrors(t *testing.T) {
-	testcase := func(body string, code int, expectedErrorCode twirp.ErrorCode, clientMaker func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
+	testcase := func(body string, code int, expectedErrorCode twirp.ErrorCode, clientMaker func(string, HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
 		return func(t *testing.T) {
 			// Make a server that returns invalid twirp error responses,
 			// simulating a network intermediary.
@@ -328,7 +328,7 @@ func TestClientIntermediaryErrors(t *testing.T) {
 		"invalidjson": `{"message":"Signature expired: 19700101T000000Z is now earlier than 20190612T110154Z (20190612T110654Z - 5 min.)"}`,
 	}
 
-	clients := map[string]func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher{
+	clients := map[string]func(string, HTTPClient, ...twirp.ClientOption) Haberdasher{
 		"json_client":  NewHaberdasherJSONClient,
 		"proto_client": NewHaberdasherProtobufClient,
 	}
@@ -502,7 +502,7 @@ func TestClientReturnsCloseErrors(t *testing.T) {
 // bodyCloseErrClient implements HTTPClient, but the response bodies it returns
 // give an error when they are closed.
 type bodyCloseErrClient struct {
-	base twirp.HTTPClient
+	base HTTPClient
 }
 
 func (c *bodyCloseErrClient) Do(req *http.Request) (*http.Response, error) {

--- a/internal/twirptest/client_test.go
+++ b/internal/twirptest/client_test.go
@@ -201,7 +201,7 @@ func TestClientSetsAcceptHeader(t *testing.T) {
 
 // If a server returns a 3xx response, give a clear error message
 func TestClientRedirectError(t *testing.T) {
-	testcase := func(code int, clientMaker func(string, HTTPClient) Haberdasher) func(*testing.T) {
+	testcase := func(code int, clientMaker func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
 		return func(t *testing.T) {
 			// Make a server that redirects all requests
 			redirecter := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +258,7 @@ func TestClientRedirectError(t *testing.T) {
 }
 
 func TestClientIntermediaryErrors(t *testing.T) {
-	testcase := func(body string, code int, expectedErrorCode twirp.ErrorCode, clientMaker func(string, HTTPClient) Haberdasher) func(*testing.T) {
+	testcase := func(body string, code int, expectedErrorCode twirp.ErrorCode, clientMaker func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher) func(*testing.T) {
 		return func(t *testing.T) {
 			// Make a server that returns invalid twirp error responses,
 			// simulating a network intermediary.
@@ -328,7 +328,7 @@ func TestClientIntermediaryErrors(t *testing.T) {
 		"invalidjson": `{"message":"Signature expired: 19700101T000000Z is now earlier than 20190612T110154Z (20190612T110654Z - 5 min.)"}`,
 	}
 
-	clients := map[string]func(string, HTTPClient) Haberdasher{
+	clients := map[string]func(string, twirp.HTTPClient, ...twirp.ClientOption) Haberdasher{
 		"json_client":  NewHaberdasherJSONClient,
 		"proto_client": NewHaberdasherProtobufClient,
 	}
@@ -502,7 +502,7 @@ func TestClientReturnsCloseErrors(t *testing.T) {
 // bodyCloseErrClient implements HTTPClient, but the response bodies it returns
 // give an error when they are closed.
 type bodyCloseErrClient struct {
-	base HTTPClient
+	base twirp.HTTPClient
 }
 
 func (c *bodyCloseErrClient) Do(req *http.Request) (*http.Response, error) {

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -10,23 +10,36 @@ It is generated from these files:
 */
 package twirptest
 
-import bytes "bytes"
-import strings "strings"
-import context "context"
-import fmt "fmt"
-import ioutil "io/ioutil"
-import http "net/http"
-import strconv "strconv"
+import (
+	bytes "bytes"
+	strings "strings"
 
-import jsonpb "github.com/golang/protobuf/jsonpb"
-import proto "github.com/golang/protobuf/proto"
-import twirp "github.com/twitchtv/twirp"
-import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+	context "context"
 
-// Imports only used by utility functions:
-import io "io"
-import json "encoding/json"
-import url "net/url"
+	fmt "fmt"
+
+	ioutil "io/ioutil"
+
+	http "net/http"
+
+	strconv "strconv"
+
+	jsonpb "github.com/golang/protobuf/jsonpb"
+
+	proto "github.com/golang/protobuf/proto"
+
+	twirp "github.com/twitchtv/twirp"
+
+	ctxsetters "github.com/twitchtv/twirp/ctxsetters"
+
+	// Imports only used by utility functions:
+
+	io "io"
+
+	json "encoding/json"
+
+	url "net/url"
+)
 
 // =====================
 // Haberdasher Interface
@@ -43,21 +56,21 @@ type Haberdasher interface {
 // ===========================
 
 type haberdasherProtobufClient struct {
-	client twirp.HTTPClient
+	client HTTPClient
 	urls   [1]string
 	opts   twirp.ClientOptions
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
 // It communicates using Protobuf and can be configured with a custom HTTPClient.
-func NewHaberdasherProtobufClient(addr string, client twirp.HTTPClient, opt ...twirp.ClientOption) Haberdasher {
-	var httpClient twirp.HTTPClient = client
+func NewHaberdasherProtobufClient(addr string, client HTTPClient, opt ...twirp.ClientOption) Haberdasher {
+	var httpClient HTTPClient = client
 
 	if c, ok := client.(*http.Client); ok {
 		httpClient = withoutRedirects(c)
 	}
 
-	opts := twirp.DefaultClientOptions(httpClient)
+	opts := twirp.DefaultClientOptions()
 	for _, o := range opt {
 		o(&opts)
 	}
@@ -78,7 +91,7 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 	ctx = ctxsetters.WithServiceName(ctx, "Haberdasher")
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
-	err := doProtobufRequest(ctx, c.opts.Client, c.urls[0], in, out)
+	err := doProtobufRequest(ctx, c.client, c.urls[0], in, out)
 	if err != nil {
 		twerr, ok := err.(twirp.Error)
 		if !ok {
@@ -103,21 +116,21 @@ func callClientError(ctx context.Context, h *twirp.ClientHooks, err twirp.Error)
 // =======================
 
 type haberdasherJSONClient struct {
-	client twirp.HTTPClient
+	client HTTPClient
 	urls   [1]string
 	opts   twirp.ClientOptions
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
 // It communicates using JSON and can be configured with a custom HTTPClient.
-func NewHaberdasherJSONClient(addr string, client twirp.HTTPClient, opt ...twirp.ClientOption) Haberdasher {
-	var httpClient twirp.HTTPClient = client
+func NewHaberdasherJSONClient(addr string, client HTTPClient, opt ...twirp.ClientOption) Haberdasher {
+	var httpClient HTTPClient = client
 
 	if c, ok := client.(*http.Client); ok {
 		httpClient = withoutRedirects(c)
 	}
 
-	opts := twirp.DefaultClientOptions(httpClient)
+	opts := twirp.DefaultClientOptions()
 	for _, o := range opt {
 		o(&opts)
 	}
@@ -138,7 +151,7 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	ctx = ctxsetters.WithServiceName(ctx, "Haberdasher")
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
-	err := doJSONRequest(ctx, c.opts.Client, c.urls[0], in, out)
+	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -12,32 +12,21 @@ package twirptest
 
 import (
 	bytes "bytes"
+	context "context"
+	fmt "fmt"
+	ioutil "io/ioutil"
+	http "net/http"
+	strconv "strconv"
 	strings "strings"
 
-	context "context"
-
-	fmt "fmt"
-
-	ioutil "io/ioutil"
-
-	http "net/http"
-
-	strconv "strconv"
-
 	jsonpb "github.com/golang/protobuf/jsonpb"
-
 	proto "github.com/golang/protobuf/proto"
-
 	twirp "github.com/twitchtv/twirp"
-
 	ctxsetters "github.com/twitchtv/twirp/ctxsetters"
 
 	// Imports only used by utility functions:
-
-	io "io"
-
 	json "encoding/json"
-
+	io "io"
 	url "net/url"
 )
 

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -138,7 +138,7 @@ func (c *haberdasherJSONClient) MakeHat(ctx context.Context, in *Size) (*Hat, er
 	ctx = ctxsetters.WithServiceName(ctx, "Haberdasher")
 	ctx = ctxsetters.WithMethodName(ctx, "MakeHat")
 	out := new(Hat)
-	err := doJSONRequest(ctx, c.client, c.urls[0], in, out)
+	err := doJSONRequest(ctx, c.opts.Client, c.urls[0], in, out)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -43,26 +43,33 @@ type Haberdasher interface {
 // ===========================
 
 type haberdasherProtobufClient struct {
-	client HTTPClient
+	client twirp.HTTPClient
 	urls   [1]string
+	opts   twirp.ClientOptions
 }
 
 // NewHaberdasherProtobufClient creates a Protobuf client that implements the Haberdasher interface.
 // It communicates using Protobuf and can be configured with a custom HTTPClient.
-func NewHaberdasherProtobufClient(addr string, client HTTPClient) Haberdasher {
+func NewHaberdasherProtobufClient(addr string, client twirp.HTTPClient, opt ...twirp.ClientOption) Haberdasher {
+	var httpClient twirp.HTTPClient = client
+
+	if c, ok := client.(*http.Client); ok {
+		httpClient = withoutRedirects(c)
+	}
+
+	opts := twirp.DefaultClientOptions(client)
+	for _, o := range opt {
+		o(&opts)
+	}
+
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
 		prefix + "MakeHat",
 	}
-	if httpClient, ok := client.(*http.Client); ok {
-		return &haberdasherProtobufClient{
-			client: withoutRedirects(httpClient),
-			urls:   urls,
-		}
-	}
 	return &haberdasherProtobufClient{
-		client: client,
+		client: httpClient,
 		urls:   urls,
+		opts:   opts,
 	}
 }
 
@@ -83,26 +90,33 @@ func (c *haberdasherProtobufClient) MakeHat(ctx context.Context, in *Size) (*Hat
 // =======================
 
 type haberdasherJSONClient struct {
-	client HTTPClient
+	client twirp.HTTPClient
 	urls   [1]string
+	opts   twirp.ClientOptions
 }
 
 // NewHaberdasherJSONClient creates a JSON client that implements the Haberdasher interface.
 // It communicates using JSON and can be configured with a custom HTTPClient.
-func NewHaberdasherJSONClient(addr string, client HTTPClient) Haberdasher {
+func NewHaberdasherJSONClient(addr string, client twirp.HTTPClient, opt ...twirp.ClientOption) Haberdasher {
+	var httpClient twirp.HTTPClient = client
+
+	if c, ok := client.(*http.Client); ok {
+		httpClient = withoutRedirects(c)
+	}
+
+	opts := twirp.DefaultClientOptions(client)
+	for _, o := range opt {
+		o(&opts)
+	}
 	prefix := urlBase(addr) + HaberdasherPathPrefix
 	urls := [1]string{
 		prefix + "MakeHat",
 	}
-	if httpClient, ok := client.(*http.Client); ok {
-		return &haberdasherJSONClient{
-			client: withoutRedirects(httpClient),
-			urls:   urls,
-		}
-	}
+
 	return &haberdasherJSONClient{
-		client: client,
+		client: httpClient,
 		urls:   urls,
+		opts:   opts,
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:* #145 

*Description of changes:*

this modifies #164 slightly to move the HTTPClient type back into the generated code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
