### PR TITLE
Don't treat NoError as valid

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -288,7 +288,7 @@ func ServerHTTPStatusFromErrorCode(code ErrorCode) int {
 
 // IsValidErrorCode returns true if is one of the valid predefined constants.
 func IsValidErrorCode(code ErrorCode) bool {
-	return ServerHTTPStatusFromErrorCode(code) != 0
+	return ServerHTTPStatusFromErrorCode(code) >= 400
 }
 
 // twirp.Error implementation


### PR DESCRIPTION
*Description of changes:*

This indirectly fixes JSON error bodies from middle entities like API Gateway being properly detected as non-twirp errors. 

Only treat codes that convert to 400 (the lowest twirp error code) or higher as valid error codes.

See https://github.com/twitchtv/twirp/blob/v5.9.0/protoc-gen-twirp/generator.go#L538 for more context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
