### PR TITLE
Return error from WriteError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -355,12 +355,12 @@ func (e *wrappedErr) Cause() error { return e.cause }
 // WriteError writes an HTTP response with a valid Twirp error format (code, msg, meta).
 // Useful outside of the Twirp server (e.g. http middleware).
 // If err is not a twirp.Error, it will get wrapped with twirp.InternalErrorWith(err)
-func WriteError(resp http.ResponseWriter, err error) {
-	writeError(resp, err)
+func WriteError(resp http.ResponseWriter, err error) error {
+	return writeError(resp, err)
 }
 
 // writeError writes Twirp errors in the response.
-func writeError(resp http.ResponseWriter, err error) {
+func writeError(resp http.ResponseWriter, err error) error {
 	// Non-twirp errors are wrapped as Internal (default)
 	twerr, ok := err.(Error)
 	if !ok {
@@ -376,17 +376,9 @@ func writeError(resp http.ResponseWriter, err error) {
 
 	_, writeErr := resp.Write(respBody)
 	if writeErr != nil {
-		// We have two options here. We could log the error, or just silently
-		// ignore the error.
-		//
-		// Logging is unacceptable because we don't have a user-controlled
-		// logger; writing out to stderr without permission is too rude.
-		//
-		// Silently ignoring the error is our least-bad option. It's highly
-		// likely that the connection is broken and the original 'err' says
-		// so anyway.
-		_ = writeErr
+		return writeErr
 	}
+	return nil
 }
 
 // JSON serialization for errors

--- a/internal/gen/wrappers.go
+++ b/internal/gen/wrappers.go
@@ -414,8 +414,8 @@ func wrapServices(file *descriptor.FileDescriptorProto) (sl []*ServiceDescriptor
 		sd := &ServiceDescriptor{
 			common:                 common{file},
 			ServiceDescriptorProto: svc,
-			Index: i,
-			Path:  fmt.Sprintf("%d,%d", servicePath, i),
+			Index:                  i,
+			Path:                   fmt.Sprintf("%d,%d", servicePath, i),
 		}
 		for j, method := range svc.Method {
 			md := &MethodDescriptor{


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/twitchtv/twirp/issues/201

*Description of changes:*

`WriteError` now returns the error it might encounter while writing.

Added tests to cover `WriteError`'s happy path and error case.

<hr>
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
