### PR TITLE
Fixed package alias for net/http

### DIFF
--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -979,7 +979,7 @@ func (t *twirp) generateClientHooks() {
 	t.P(`  h.ResponseReceived(ctx)`)
 	t.P(`}`)
 	t.P()
-	t.P(`func callClientRequestPrepared(ctx `, t.pkgs["context"], `.Context, h *`, t.pkgs["twirp"], `.ClientHooks, req *http.Request) (`, t.pkgs["context"], `.Context, error) {`)
+	t.P(`func callClientRequestPrepared(ctx `, t.pkgs["context"], `.Context, h *`, t.pkgs["twirp"], `.ClientHooks, req *`, t.pkgs["http"], `.Request) (`, t.pkgs["context"], `.Context, error) {`)
 	t.P(`  if h == nil || h.RequestPrepared == nil {`)
 	t.P(`    return ctx, nil`)
 	t.P(`  }`)

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -615,7 +615,7 @@ func (t *twirp) generateUtils() {
 	t.P(`		// Actually write the error`)
 	t.P(`		writeError(ctx, resp, twerr, hooks)`)
 	t.P(`		// If possible, flush the error to the wire.`)
-	t.P(`		f, ok := resp.(http.Flusher)`)
+	t.P(`		f, ok := resp.(`, t.pkgs["http"], `.Flusher)`)
 	t.P(`		if ok {`)
 	t.P(`			f.Flush()`)
 	t.P(`		}`)


### PR DESCRIPTION
Due to some extension used in my *.proto files I have following alias in the generated code:
```go
import http1 "net/http"
```

Compiler gives me the following error:
```
service.twirp.go:1023:80: undefined: http
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
