### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -16,6 +16,10 @@ const users = [
 ];
 
 const siteConfig = {
+    algolia: {
+        apiKey: 'a2da0312a57f35d6e937107b5f0ec698',
+        indexName: 'twitchtv_twirp',
+    },
     title: 'Twirp' /* title for your website */,
     tagline: 'Simple RPC framework powered by protobuf',
     url: 'https://twitchtv.github.io' /* your website url */,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.