### PR TITLE
AddHTTPResponseHeader to allow responseWriter.Header().Add() in addition to Set

### DIFF
--- a/context.go
+++ b/context.go
@@ -124,22 +124,10 @@ func SetHTTPResponseHeader(ctx context.Context, key, value string) error {
 	return nil
 }
 
-// AddHTTPResponseHeader adds an HTTP header key-value pair using a context
-// provided by a twirp-generated server, or a child of that context.
-// The server will include the header in its response for that request context.
+// AddHTTPResponseHeader behaves like SetHTTPResponseHeader,
+// but it appends the key-value pair to the header (instead of replacing it).
 //
-// This can be used to respond with custom HTTP headers like "Cache-Control".
-// But note that HTTP headers are a Twirp implementation detail,
-// only visible by middleware, not by the clients or their responses.
-//
-// The header will be ignored (noop) if the context is invalid (i.e. using a new
-// context.Background() instead of passing the context from the handler).
-//
-// If called multiple times with the same key, it appends to any existing values
-// associated with that key.
-//
-// AddHTTPResponseHeader returns an error if the provided header key
-// would overwrite a header that is needed by Twirp, like "Content-Type".
+// AddHTTPResponseHeader returns an error if the key is "Content-Type".
 func AddHTTPResponseHeader(ctx context.Context, key, value string) error {
 	if key == "Content-Type" {
 		return errors.New("header key can not be Content-Type")

--- a/context.go
+++ b/context.go
@@ -140,16 +140,14 @@ func SetHTTPResponseHeader(ctx context.Context, key, value string) error {
 //
 // AddHTTPResponseHeader returns an error if the provided header key
 // would overwrite a header that is needed by Twirp, like "Content-Type".
-func AddHTTPResponseHeader(ctx context.Context, key string, values ...string) error {
+func AddHTTPResponseHeader(ctx context.Context, key, value string) error {
 	if key == "Content-Type" {
 		return errors.New("header key can not be Content-Type")
 	}
 
 	responseWriter, ok := ctx.Value(contextkeys.ResponseWriterKey).(http.ResponseWriter)
 	if ok {
-		for _, v := range values {
-			responseWriter.Header().Add(key, v)
-		}
+		responseWriter.Header().Add(key, value)
 	} // invalid context is ignored, not an error, this is to allow easy unit testing with mock servers
 
 	return nil

--- a/context.go
+++ b/context.go
@@ -111,14 +111,16 @@ func HTTPRequestHeaders(ctx context.Context) (http.Header, bool) {
 //
 // SetHTTPResponseHeader returns an error if the provided header key
 // would overwrite a header that is needed by Twirp, like "Content-Type".
-func SetHTTPResponseHeader(ctx context.Context, key, value string) error {
+func SetHTTPResponseHeader(ctx context.Context, key string, values ...string) error {
 	if key == "Content-Type" {
 		return errors.New("header key can not be Content-Type")
 	}
 
 	responseWriter, ok := ctx.Value(contextkeys.ResponseWriterKey).(http.ResponseWriter)
 	if ok {
-		responseWriter.Header().Set(key, value)
+		for _, v := range values {
+			responseWriter.Header().Add(key, v)
+		}
 	} // invalid context is ignored, not an error, this is to allow easy unit testing with mock servers
 
 	return nil

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -69,7 +69,7 @@ func (h *myServer) MyRPC(ctx context.Context, req *pb.Req) (*pb.Resp, error) {
   return &pb.Resp{}, nil
 }
 ```
-You can also use `twirp.AddHTTPResponseHeader` to add values to the key that is already exists.
+`twirp.AddHTTPResponseHeader` can be used to append values to a header.
 
 ### Read HTTP Headers from requests
 

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -69,6 +69,7 @@ func (h *myServer) MyRPC(ctx context.Context, req *pb.Req) (*pb.Resp, error) {
   return &pb.Resp{}, nil
 }
 ```
+You can also use `twirp.AddHTTPResponseHeader` to add values to the key that is already exists.
 
 ### Read HTTP Headers from requests
 

--- a/internal/twirptest/service_test.go
+++ b/internal/twirptest/service_test.go
@@ -1020,11 +1020,11 @@ func TestCustomResponseHeaders(t *testing.T) {
 			t.Fatalf(errMsg + err.Error())
 		}
 
-		err = twirp.SetHTTPResponseHeader(ctx, "key2", "before_override")
+		err = twirp.SetHTTPResponseHeader(ctx, "key2", "before_append")
 		if err != nil {
 			t.Fatalf(errMsg + err.Error())
 		}
-		err = twirp.SetHTTPResponseHeader(ctx, "key2", "val2") // should override
+		err = twirp.SetHTTPResponseHeader(ctx, "key2", "val2") // should append
 		if err != nil {
 			t.Fatalf(errMsg + err.Error())
 		}
@@ -1055,8 +1055,8 @@ func TestCustomResponseHeaders(t *testing.T) {
 		if w.Header().Get("key1") != "val1" {
 			t.Errorf("expected 'key1' header to be 'val1', but found %q", w.Header().Get("key1"))
 		}
-		if w.Header().Get("key2") != "val2" {
-			t.Errorf("expected 'key2' header to be 'val2', but found %q", w.Header().Get("key2"))
+		if w.Header().Get("key2") != "before_append" {
+			t.Errorf("expected 'key2' header to be 'before_append', but found %q", w.Header().Get("key2"))
 		}
 		if w.Header().Get("key3") != "val3" {
 			t.Errorf("expected 'key3' header to be 'val3', but found %q", w.Header().Get("key3"))

--- a/internal/twirptest/service_test.go
+++ b/internal/twirptest/service_test.go
@@ -1020,11 +1020,11 @@ func TestCustomResponseHeaders(t *testing.T) {
 			t.Fatalf(errMsg + err.Error())
 		}
 
-		err = twirp.SetHTTPResponseHeader(ctx, "key2", "before_append")
+		err = twirp.SetHTTPResponseHeader(ctx, "key2", "before_override")
 		if err != nil {
 			t.Fatalf(errMsg + err.Error())
 		}
-		err = twirp.SetHTTPResponseHeader(ctx, "key2", "val2") // should append
+		err = twirp.SetHTTPResponseHeader(ctx, "key2", "val2") // should override
 		if err != nil {
 			t.Fatalf(errMsg + err.Error())
 		}
@@ -1036,6 +1036,15 @@ func TestCustomResponseHeaders(t *testing.T) {
 		}
 
 		err = twirp.SetHTTPResponseHeader(context.Background(), "key4", "should_be_ignored")
+		if err != nil {
+			t.Fatalf(errMsg + err.Error())
+		}
+
+		err = twirp.AddHTTPResponseHeader(ctx, "key5", "val5", "val6")
+		if err != nil {
+			t.Fatalf(errMsg + err.Error())
+		}
+		err = twirp.AddHTTPResponseHeader(ctx, "key5", "val7") // should append
 		if err != nil {
 			t.Fatalf(errMsg + err.Error())
 		}
@@ -1055,14 +1064,17 @@ func TestCustomResponseHeaders(t *testing.T) {
 		if w.Header().Get("key1") != "val1" {
 			t.Errorf("expected 'key1' header to be 'val1', but found %q", w.Header().Get("key1"))
 		}
-		if w.Header().Get("key2") != "before_append" {
-			t.Errorf("expected 'key2' header to be 'before_append', but found %q", w.Header().Get("key2"))
+		if w.Header().Get("key2") != "val2" {
+			t.Errorf("expected 'key2' header to be 'val2', but found %q", w.Header().Get("key2"))
 		}
 		if w.Header().Get("key3") != "val3" {
 			t.Errorf("expected 'key3' header to be 'val3', but found %q", w.Header().Get("key3"))
 		}
 		if w.Header().Get("key4") == "should_be_ignored" {
 			t.Error("expected 'key4' header to be empty, it should be ignored if the context is not coming from the handler")
+		}
+		if w.Header().Get("key5") != "val5" {
+			t.Errorf("expected 'key5' header to be 'val5', but found %q", w.Header().Get("key5"))
 		}
 	})
 

--- a/internal/twirptest/service_test.go
+++ b/internal/twirptest/service_test.go
@@ -1040,7 +1040,7 @@ func TestCustomResponseHeaders(t *testing.T) {
 			t.Fatalf(errMsg + err.Error())
 		}
 
-		err = twirp.AddHTTPResponseHeader(ctx, "key5", "val5", "val6")
+		err = twirp.AddHTTPResponseHeader(ctx, "key5", "val5")
 		if err != nil {
 			t.Fatalf(errMsg + err.Error())
 		}


### PR DESCRIPTION
*Description of changes:*
Hi! I always use your wonderful library `twirp`.

I'd like to set multiple variables to the response header in the same key.
So I replaces `responseWriter.Header().Set()` with `responseWriter.Header().Add()`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
