### PR TITLE
Allow wrapping any error code, not just Internal errors

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -100,3 +100,17 @@ func TestWriteError(t *testing.T) {
 		t.Errorf("did not get error on write. have=nil, want=some error")
 	}
 }
+
+func TestWrapError(t *testing.T) {
+	rootCause := errors.New("cause")
+	twerr := NewError(NotFound, "it ain't there")
+	err := WrapError(twerr, rootCause)
+	cause := errors.Cause(err)
+	if cause != rootCause {
+		t.Errorf("got wrong cause. got=%q, want=%q", cause, rootCause)
+	}
+	wantMsg := "twirp error not_found: it ain't there"
+	if gotMsg := err.Error(); gotMsg != wantMsg {
+		t.Errorf("got wrong error text. got=%q, want=%q", gotMsg, wantMsg)
+	}
+}


### PR DESCRIPTION
And support the Unwrap() method in addition to Cause()

Issue #228 

*Description of changes:*

Add a function `WrapError(ErrorCode, error) Error`, which allows wrapping an error with any error code, not just Internal errors.

And add the `Unwrap()` method to the `wrappedErr` type, to be compatible with Go 1.13's new error unwrapping.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
