### PR TITLE
Include response body in metadata when server returns invalid code

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -722,7 +722,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -548,7 +548,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/empty_service/empty_service.twirp.go
+++ b/internal/twirptest/empty_service/empty_service.twirp.go
@@ -366,7 +366,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -550,7 +550,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/google_protobuf_imports/service.twirp.go
+++ b/internal/twirptest/google_protobuf_imports/service.twirp.go
@@ -549,7 +549,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -549,7 +549,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -551,7 +551,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/importmapping/x/x.twirp.go
+++ b/internal/twirptest/importmapping/x/x.twirp.go
@@ -548,7 +548,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -550,7 +550,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -546,7 +546,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -548,7 +548,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -549,7 +549,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -548,7 +548,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
+++ b/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
@@ -546,7 +546,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/snake_case_names/snake_case_names.twirp.go
+++ b/internal/twirptest/snake_case_names/snake_case_names.twirp.go
@@ -551,7 +551,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/internal/twirptest/source_relative/source_relative.twirp.go
+++ b/internal/twirptest/source_relative/source_relative.twirp.go
@@ -546,7 +546,7 @@ func errorFromResponse(resp *http.Response) twirp.Error {
 	errorCode := twirp.ErrorCode(tj.Code)
 	if !twirp.IsValidErrorCode(errorCode) {
 		msg := "invalid type returned from server error response: " + tj.Code
-		return twirp.InternalError(msg)
+		return twirp.InternalError(msg).WithMeta("body", string(respBodyBytes))
 	}
 
 	twerr := twirp.NewError(errorCode, tj.Msg)

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -538,7 +538,7 @@ func (t *twirp) generateUtils() {
 	t.P(`  errorCode := `, t.pkgs["twirp"], `.ErrorCode(tj.Code)`)
 	t.P(`  if !`, t.pkgs["twirp"], `.IsValidErrorCode(errorCode) {`)
 	t.P(`    msg := "invalid type returned from server error response: "+tj.Code`)
-	t.P(`    return `, t.pkgs["twirp"], `.InternalError(msg)`)
+	t.P(`    return `, t.pkgs["twirp"], `.InternalError(msg).WithMeta("body", string(respBodyBytes))`)
 	t.P(`  }`)
 	t.P(``)
 	t.P(`  twerr := `, t.pkgs["twirp"], `.NewError(errorCode, tj.Msg)`)


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/twitchtv/twirp/issues/233

*Description of changes:*

This adds the "body" metadata to the response when the err code is missing or invalid

I have updated `generator.go` and ran `retool do go generate ./...` -- hopefully this was the correct process. But definitely let me know if I need to do anything different. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
