### PR TITLE
Spec compatibility for go server and client

### DIFF
--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -1415,7 +1415,7 @@ func (t *twirp) formattedOutput() string {
 func unexported(s string) string { return strings.ToLower(s[:1]) + s[1:] }
 
 func fullServiceName(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) string {
-	name := serviceName(service)
+	name := stringutils.CamelCase(service.GetName())
 	if pkg := pkgName(file); pkg != "" {
 		name = pkg + "." + name
 	}

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -1074,11 +1074,7 @@ func pathFor(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDe
 // particular method on a particular service.
 // This method is here to ensure compatibility with older clients.
 func pathForCamelOld(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto, method *descriptor.MethodDescriptorProto) string {
-	name := stringutils.CamelCase(service.GetName())
-	if pkg := pkgName(file); pkg != "" {
-		name = pkg + "." + name
-	}
-	return fmt.Sprintf("/twirp/%s/%s", name, stringutils.CamelCase(method.GetName()))
+	return pathPrefix(file, service) + stringutils.CamelCase(method.GetName())
 }
 
 func (t *twirp) generateServerRouting(servStruct string, file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) {
@@ -1419,7 +1415,7 @@ func (t *twirp) formattedOutput() string {
 func unexported(s string) string { return strings.ToLower(s[:1]) + s[1:] }
 
 func fullServiceName(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) string {
-	name := service.GetName()
+	name := serviceName(service)
 	if pkg := pkgName(file); pkg != "" {
 		name = pkg + "." + name
 	}

--- a/protoc-gen-twirp_python/main.go
+++ b/protoc-gen-twirp_python/main.go
@@ -211,7 +211,7 @@ func clientName(service *descriptor.ServiceDescriptorProto) string {
 }
 
 func fullServiceName(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) string {
-	name := service.GetName()
+	name := serviceName(service)
 	if pkg := file.GetPackage(); pkg != "" {
 		name = pkg + "." + name
 	}

--- a/protoc-gen-twirp_python/main.go
+++ b/protoc-gen-twirp_python/main.go
@@ -211,7 +211,7 @@ func clientName(service *descriptor.ServiceDescriptorProto) string {
 }
 
 func fullServiceName(file *descriptor.FileDescriptorProto, service *descriptor.ServiceDescriptorProto) string {
-	name := serviceName(service)
+	name := service.GetName()
 	if pkg := file.GetPackage(); pkg != "" {
 		name = pkg + "." + name
 	}


### PR DESCRIPTION
*Issue #, if available:* #244 

Through a PR on twirpy, I discovered that the go and python official implementations do not conform to the spec wrt CamelCasing the URL. There is a difference between the python client and go server implementation as well.

My initial assumption was go might be the reference implementation and spec kind of follows the behaviour in go generated code. So I opened #244 to ask if/how we should add clarification on the spec.

@spenczar pointed out that it is probably supposed to be the other way around.

*Overview of choices*

The major trade off seems to be between breaking change in spec vs the go server implementation.

The fact that this hasn't been an issue so far is most probably because people using twirp, especially in other languages, make their service and method names CamelCased anyway.
That might be at least some weak evidence in favour of doubling down on camel case requirement for all implementations.

On the other hand, it an also be seen as the impact of a breaking change might not be that big.

If we think of twirp as a serious alternative to gRPC and REST, we're still in the early stages of the lifetime penetration it will have across languages. This project relies heavily on community implementations of the spec for that.

A move to maintain simplicity of the spec might be of greater importance from that view.

*Description of changes:*

This PR pre-emptively assumes we want to go towards being compatible with the spec and switch the go implementation over time. So it takes the first safe step towards that.

For the service definition
```protobuf
package simple;
service hello {
    rpc world(msg) returns(msg);
}
```

Go server now accepts both cases of method name to ensure compatibility with older go clients:
1. `/twirp/simple.Hello/world`
2. `/twirp/simple.Hello/World`

Go client sends requests to `/twirp/simple.Hello/world`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
