### PR TITLE
Add elixir to third party implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For other languages, there are third-party generators available:
 | **Swagger**    |    ✓    |    ✓    | [github.com/elliots/protoc-gen-twirp_swagger](https://github.com/elliots/protoc-gen-twirp_swagger)
 | **PHP**        |    ✓    |    ✓    | [github.com/twirphp/twirp](https://github.com/twirphp/twirp)
 | **Dart**       |    ✓    |         | [github.com/apptreesoftware/protoc-gen-twirp_dart](https://github.com/apptreesoftware/protoc-gen-twirp_dart)
+| **Elixir**     |    ✓    |    ✓    | [github.com/keathley/twirp-elixir](https://github.com/keathley/twirp-elixir)
 
 This list isn't an endorsement, it's just a convenience to help you find stuff
 for your language.


### PR DESCRIPTION
Thanks for putting all the work into this. I just wanted to add our elixir implementation to the list.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.