### PR TITLE
Add support for TooManyRequests (429) error code

### DIFF
--- a/clientcompat/main.go
+++ b/clientcompat/main.go
@@ -112,7 +112,7 @@ func testNoop(cc *clientCompat, s *httptest.Server, clientBin string) {
 		twirp.NotFound, twirp.BadRoute, twirp.AlreadyExists, twirp.PermissionDenied,
 		twirp.Unauthenticated, twirp.ResourceExhausted, twirp.FailedPrecondition,
 		twirp.Aborted, twirp.OutOfRange, twirp.Unimplemented, twirp.Internal,
-		twirp.Unavailable, twirp.DataLoss,
+		twirp.Unavailable, twirp.DataLoss, twirp.TooManyRequests,
 	} {
 		testcase(
 			fmt.Sprintf("%q error parsing", code),

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -60,6 +60,7 @@ Each error code is defined by a constant in the `twirp` package:
 | Internal           | internal            | 500 Internal Server Error
 | Unavailable        | unavailable         | 503 Service Unavailable
 | DataLoss           | dataloss            | 500 Internal Server Error
+| TooManyRequests    | too_many_requests   | 429 Too Many Requests
 
 For more information on each code, see the [Errors Spec](spec_v5.md).
 

--- a/docs/spec_v5.md
+++ b/docs/spec_v5.md
@@ -214,5 +214,5 @@ corresponding HTTP Status Code for the response.
 | internal            | 500 | When some invariants expected by the underlying system have been broken. In other words, something bad happened in the library or backend service. Twirp specific issues like wire and serialization problems are also reported as "internal" errors.
 | unavailable         | 503 | The service is currently unavailable. This is most likely a transient condition and may be corrected by retrying with a backoff.
 | dataloss            | 500 | The operation resulted in unrecoverable data loss or corruption.
-
+| too_many_requests   | 429 | The client is making too many requests. They should slow down their rate of requests.
 

--- a/errors.go
+++ b/errors.go
@@ -233,6 +233,9 @@ const (
 	// DataLoss indicates unrecoverable data loss or corruption.
 	DataLoss ErrorCode = "data_loss"
 
+	// TooManyRequests indicates that the client is making too many requests.
+	TooManyRequests ErrorCode = "too_many_requests"
+
 	// NoError is the zero-value, is considered an empty error and should not be
 	// used.
 	NoError ErrorCode = ""
@@ -279,6 +282,8 @@ func ServerHTTPStatusFromErrorCode(code ErrorCode) int {
 		return 503 // Service Unavailable
 	case DataLoss:
 		return 500 // Internal Server Error
+	case TooManyRequests:
+		return 429 // Too Many Requests
 	case NoError:
 		return 200 // OK
 	default:


### PR DESCRIPTION
Add support for a "TooManyRequests" Twirp error code, which will get translated to the equivalent 429 HTTP error code. 

> Why call this `TooManyRequests` instead of `RateLimitExceeded`? 

I'm not super particular with the exact naming here and would be happy to move to something like `RateLimitExceeded` if others think this is better, but on initial glance exactly matching the corresponding code from the HTTP spec seemed valuable. 

> Why not use the existing `ResourceExhausted` error code to indicate the client should slow down

Technically, exceeding a rate limit could be considered "exhausting a per-user quota" and be represented by the existing `ResourceExhausted` error. However, on first glance, my interpretation of receiving a `ResourceExhausted` error code _as a client caller_ is that something is problematic or damaged on the server, not that my request pattern as a client is faulty. In fact, the Twirp service may be completely healthy, but choose to reject a client's traffic because it breaks some negotiated rate limit, even if it could handle the traffic just fine without exhausting its resources. In addition, there are many potential situations where there are no user-level limits and yet rate limiting is still expected. For example, a Twirp service may place global rate limit  across all callers on a very expensive API operation to ensure a downstream remains healthy. 

Secondly, breaking this out into its own error code allows the very simple creation of rate-limiting Twirp middleware via `ServerHooks`. If we chose to reuse the existing `ResourceExhausted` error code, any middleware would have to inspect both the error code as well as actual error message to ensure that the `ResourceExhausted` error received was due to rate limiting instead of some other generic resource exhaustion. Checking the error message directly is more brittle to changes. 

In my mind, having a error code that either strictly or loosely correlates with the 429 `TooManyRequests` error code from the HTTP spec is valuable for both Twirp clients, service developers and the Twirp ecosystem as a whole. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
