### PR TITLE
Add version_constant and check from generated code

### DIFF
--- a/clientcompat/internal/clientcompat/clientcompat.twirp.go
+++ b/clientcompat/internal/clientcompat/clientcompat.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =======================
 // CompatService Interface
 // =======================

--- a/example/service.twirp.go
+++ b/example/service.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =====================
 // Haberdasher Interface
 // =====================

--- a/internal/twirptest/empty_service/empty_service.twirp.go
+++ b/internal/twirptest/empty_service/empty_service.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ===============
 // Empty Interface
 // ===============

--- a/internal/twirptest/gogo_compat/service.twirp.go
+++ b/internal/twirptest/gogo_compat/service.twirp.go
@@ -33,6 +33,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/internal/twirptest/google_protobuf_imports/service.twirp.go
+++ b/internal/twirptest/google_protobuf_imports/service.twirp.go
@@ -32,6 +32,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/internal/twirptest/importable/importable.twirp.go
+++ b/internal/twirptest/importable/importable.twirp.go
@@ -32,6 +32,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/internal/twirptest/importer/importer.twirp.go
+++ b/internal/twirptest/importer/importer.twirp.go
@@ -34,6 +34,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ==============
 // Svc2 Interface
 // ==============

--- a/internal/twirptest/importer_local/importer_local.twirp.go
+++ b/internal/twirptest/importer_local/importer_local.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/internal/twirptest/importmapping/x/x.twirp.go
+++ b/internal/twirptest/importmapping/x/x.twirp.go
@@ -31,6 +31,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ==============
 // Svc1 Interface
 // ==============

--- a/internal/twirptest/multiple/multiple1.twirp.go
+++ b/internal/twirptest/multiple/multiple1.twirp.go
@@ -33,6 +33,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ==============
 // Svc1 Interface
 // ==============

--- a/internal/twirptest/multiple/multiple2.twirp.go
+++ b/internal/twirptest/multiple/multiple2.twirp.go
@@ -16,6 +16,12 @@ import proto "github.com/golang/protobuf/proto"
 import twirp "github.com/twitchtv/twirp"
 import ctxsetters "github.com/twitchtv/twirp/ctxsetters"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ==============
 // Svc2 Interface
 // ==============

--- a/internal/twirptest/no_package_name/no_package_name.twirp.go
+++ b/internal/twirptest/no_package_name/no_package_name.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
+++ b/internal/twirptest/no_package_name_importer/no_package_name_importer.twirp.go
@@ -31,6 +31,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ==============
 // Svc2 Interface
 // ==============

--- a/internal/twirptest/proto/proto.twirp.go
+++ b/internal/twirptest/proto/proto.twirp.go
@@ -32,6 +32,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/internal/twirptest/service.twirp.go
+++ b/internal/twirptest/service.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =====================
 // Haberdasher Interface
 // =====================

--- a/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
+++ b/internal/twirptest/service_method_same_name/service_method_same_name.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // ==============
 // Echo Interface
 // ==============

--- a/internal/twirptest/snake_case_names/snake_case_names.twirp.go
+++ b/internal/twirptest/snake_case_names/snake_case_names.twirp.go
@@ -33,6 +33,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =======================
 // HaberdasherV1 Interface
 // =======================

--- a/internal/twirptest/source_relative/source_relative.twirp.go
+++ b/internal/twirptest/source_relative/source_relative.twirp.go
@@ -29,6 +29,12 @@ import json "encoding/json"
 import path "path"
 import url "net/url"
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the twirp package used in your project.
+// A compilation error at this line likely means your copy of the
+// twirp package needs to be updated.
+const _ = twirp.TwirpPackageIsVersion7
+
 // =============
 // Svc Interface
 // =============

--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -223,6 +223,8 @@ func (t *twirp) generate(file *descriptor.FileDescriptorProto) *plugin.CodeGener
 		t.generateUtilImports()
 	}
 
+	t.generateVersionCheck(file)
+
 	// For each service, generate client stubs and server
 	for i, service := range file.Service {
 		t.generateService(file, service, i)
@@ -241,6 +243,14 @@ func (t *twirp) generate(file *descriptor.FileDescriptorProto) *plugin.CodeGener
 
 	t.filesHandled++
 	return resp
+}
+
+func (t *twirp) generateVersionCheck(file *descriptor.FileDescriptorProto) {
+	t.P(`// This is a compile-time assertion to ensure that this generated file`)
+	t.P(`// is compatible with the twirp package used in your project.`)
+	t.P(`// A compilation error at this line likely means your copy of the`)
+	t.P(`// twirp package needs to be updated.`)
+	t.P(`const _ = `, t.pkgs["twirp"], `.TwirpPackageIsVersion7`)
 }
 
 func (t *twirp) generateFileHeader(file *descriptor.FileDescriptorProto) {

--- a/version_constant.go
+++ b/version_constant.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Twitch Interactive, Inc.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the License is
+// located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package twirp
+
+// TwirpPackageIsVersion7 is a constant referenced from generated code thar
+// requires the twirp package version 7. Older versions don't have this
+// constant defined, causing a compiler error for the version conflict. 
+const TwirpPackageIsVersion7 = true

--- a/version_constant.go
+++ b/version_constant.go
@@ -13,7 +13,7 @@
 
 package twirp
 
-// TwirpPackageIsVersion7 is a constant referenced from generated code thar
-// requires the twirp package version 7. Older versions don't have this
-// constant defined, causing a compiler error for the version conflict. 
+// TwirpPackageIsVersion7 is a constant referenced from generated code that
+// requires features on this version of the twirp package. Older versions
+// don't have this constant defined, causing a compile-time assetion error.
 const TwirpPackageIsVersion7 = true


### PR DESCRIPTION
The PR #264 includes new server options in the `twirp` package that are used by the generated code. If the `protoc-gen-twirp` plugin used to generate code uses the latest version, but the `twirp` package in the project is an older version, the generated code will fail with a compile-time error. Without this constant, the error is something like `clientOpts.PathPrefix() function does not exist`. With this constant, the error is more descriptive, like `twirp.TwirpPackageIsVersion7 does not exist`, which better points to the solution.

This pattern is similar to protobuf generated code, that uses compile-time assertions like `proto.ProtoPackageIsVersion4` to make sure the right version of the proto library is included in the destination project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
