### PR TITLE
Match stale-xyz-message with days-before-stale

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -11,8 +11,8 @@ jobs: # Job to close stale PRs and issues. Documentation on the github action ht
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label / comment or this will be closed in 5 days'
-        stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label / comment or this will be closed in 5 days'
+        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label / comment or this will be closed in 5 days'
+        stale-pr-message: 'This PR is stale because it has been open for 60 days with no activity. Remove stale label / comment or this will be closed in 5 days'
         days-before-stale: 60
         days-before-close: 5
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
*Description of changes:*

This is a follow-up to #283 to correct the message that gets posted in stale issues and PRs to reflect the 60-day stale period.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
