### PR TITLE
Fix go_option that contains both path and pkg

### DIFF
--- a/protoc-gen-twirp/go_naming.go
+++ b/protoc-gen-twirp/go_naming.go
@@ -31,6 +31,9 @@ func goPackageOption(f *descriptor.FileDescriptorProto) (impPath, pkg string, ok
 		return
 	}
 	ok = true
+	if bits := strings.Split(pkg, ";"); len(bits) == 2 {
+		return bits[0], bits[1], ok
+	}
 	// The presence of a slash implies there's an import path.
 	slash := strings.LastIndex(pkg, "/")
 	if slash < 0 {

--- a/protoc-gen-twirp/go_naming_test.go
+++ b/protoc-gen-twirp/go_naming_test.go
@@ -13,13 +13,15 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
 
 func TestParseGoPackageOption(t *testing.T) {
 	testcase := func(in, wantImport, wantPkg string) func(*testing.T) {
 		return func(t *testing.T) {
-			in := ""
-			wantImport, wantPkg := "", ""
 			haveImport, havePkg := parseGoPackageOption(in)
 			if haveImport != wantImport {
 				t.Errorf("wrong importPath, have=%q want=%q", haveImport, wantImport)
@@ -35,4 +37,33 @@ func TestParseGoPackageOption(t *testing.T) {
 	t.Run("full import", testcase("github.com/example/foo", "github.com/example/foo", "foo"))
 	t.Run("full import with override",
 		testcase("github.com/example/foo;bar", "github.com/example/foo", "bar"))
+	t.Run("non dotted import with package", testcase("foo;bar", "foo", "bar"))
+}
+
+func TestGoPackageOption(t *testing.T) {
+	testcase := func(in, wantImport, wantPkg string, wantOK bool) func(*testing.T) {
+		return func(t *testing.T) {
+			haveImport, havePkg, haveOK := goPackageOption(&descriptor.FileDescriptorProto{
+				Options: &descriptor.FileOptions{
+					GoPackage: &in,
+				},
+			})
+			if wantOK != haveOK {
+				t.Errorf("wrong ok, have=%t want=%t", haveOK, wantOK)
+			}
+			if haveImport != wantImport {
+				t.Errorf("wrong importPath, have=%q want=%q", haveImport, wantImport)
+			}
+			if havePkg != wantPkg {
+				t.Errorf("wrong packageName, have=%q want=%q", havePkg, wantPkg)
+			}
+		}
+	}
+
+	t.Run("empty string", testcase("", "", "", false))
+	t.Run("bare package", testcase("foo", "", "foo", true))
+	t.Run("full import", testcase("github.com/example/foo", "github.com/example/foo", "foo", true))
+	t.Run("full import with override",
+		testcase("github.com/example/foo;bar", "github.com/example/foo", "bar", true))
+	t.Run("non dotted import with package", testcase("foo;bar", "foo", "bar", true))
 }


### PR DESCRIPTION
This PR adds a new check to the `go_option` parser to see if it includes a semi-colon. If it does, that means the user has already provided both the import path as well as the package name and that Twirp shouldn't try to deduce either of them. 

In protobuf-go's v2, this is going to be the new default. See the referenced issue for more details. 

Fixes https://github.com/twitchtv/twirp/issues/280

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.