### PR TITLE
Add ErrorCode PayloadTooLarge

### DIFF
--- a/clientcompat/main.go
+++ b/clientcompat/main.go
@@ -112,7 +112,7 @@ func testNoop(cc *clientCompat, s *httptest.Server, clientBin string) {
 		twirp.NotFound, twirp.BadRoute, twirp.AlreadyExists, twirp.PermissionDenied,
 		twirp.Unauthenticated, twirp.ResourceExhausted, twirp.FailedPrecondition,
 		twirp.Aborted, twirp.OutOfRange, twirp.Unimplemented, twirp.Internal,
-		twirp.Unavailable, twirp.DataLoss,
+		twirp.Unavailable, twirp.DataLoss, twirp.PayloadTooLarge,
 	} {
 		testcase(
 			fmt.Sprintf("%q error parsing", code),

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -51,6 +51,7 @@ Each error code is defined by a constant in the `twirp` package:
 | BadRoute           | bad_route           | 404 Not Found
 | AlreadyExists      | already_exists      | 409 Conflict
 | PermissionDenied   | permission_denied   | 403 Forbidden
+| PayloadTooLarge   | payload_too_large   | 413 Payload Too Large
 | Unauthenticated    | unauthenticated     | 401 Unauthorized
 | ResourceExhausted  | resource_exhausted  | 429 Too Many Requests
 | FailedPrecondition | failed_precondition | 412 Precondition Failed

--- a/errors.go
+++ b/errors.go
@@ -161,6 +161,10 @@ const (
 	// disagreement in message format between the client and server.
 	Malformed ErrorCode = "malformed"
 
+	// PayloadTooLarge error means that request length is larger than the limits
+	// set by server
+	PayloadTooLarge ErrorCode = "payload_too_large"
+
 	// DeadlineExceeded means operation expired before completion. For operations
 	// that change the state of the system, this error may be returned even if the
 	// operation has completed successfully (timeout).
@@ -259,6 +263,8 @@ func ServerHTTPStatusFromErrorCode(code ErrorCode) int {
 		return 404 // Not Found
 	case AlreadyExists:
 		return 409 // Conflict
+	case PayloadTooLarge:
+		return 413 // Payload Too Large
 	case PermissionDenied:
 		return 403 // Forbidden
 	case Unauthenticated:


### PR DESCRIPTION
*Description of changes:*

Currently there is no way to send an error when the request body is too large. Added a new error `PayloadTooLarge`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
