### PR TITLE
Make example work

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -29,7 +29,7 @@ definition file, placed in `rpc/haberdasher/service.proto`:
 syntax = "proto3";
 
 package twirp.example.haberdasher;
-option go_package = "haberdasher";
+option go_package = "./;haberdasher";
 
 // Haberdasher service makes hats for clients.
 service Haberdasher {


### PR DESCRIPTION


By following the example, you run into this issue. 

<img width="985" alt="Screen Shot 2021-04-26 at 6 25 31 PM" src="https://user-images.githubusercontent.com/4060187/116158496-c9860c80-a6bc-11eb-89ef-67a28accb0b1.png">

This PR fixes this w/ relative path tweak suggested here: https://github.com/techschool/pcbook-go/issues/3




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
