### PR TITLE
Make sure import list is ordered

### DIFF
--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -22,6 +22,7 @@ import (
 	"go/printer"
 	"go/token"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -337,8 +338,13 @@ func (t *twirp) generateImports(file *descriptor.FileDescriptorProto) {
 			}
 		}
 	}
-	for pkg, importPath := range deps {
-		t.P(`import `, pkg, ` `, importPath)
+	pkgs := make([]string, 0, len(deps))
+	for pkg := range deps {
+		pkgs = append(pkgs, pkg)
+	}
+	sort.Strings(pkgs)
+	for _, pkg := range pkgs {
+		t.P(`import `, pkg, ` `, deps[pkg])
 	}
 	if len(deps) > 0 {
 		t.P()


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/twitchtv/twirp/issues/298

*Description of changes:*

Before writing out package names, append them to a slice and sort them.
This keeps the import list remaining in the same order. Otherwise, the generated protobuf `*.go` files may change even though `*.proto` is the same, which causes trouble in our CI environment.

I'm having trouble coming up with a test for this change. Any example I could look at?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.