### PR TITLE
Fix clientcompat for APIV2

### DIFF
--- a/clientcompat/main.go
+++ b/clientcompat/main.go
@@ -17,11 +17,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"google.golang.org/protobuf/proto"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 
 	"github.com/twitchtv/twirp"
 	"github.com/twitchtv/twirp/clientcompat/internal/clientcompat"
@@ -161,7 +161,7 @@ func testMethod(cc *clientCompat, s *httptest.Server, clientBin string) {
 			return
 		}
 
-		if !reflect.DeepEqual(resp, wantResp) {
+		if !proto.Equal(resp, wantResp) {
 			fail("client has wrong response, have %+v want %+v", resp, wantResp)
 			return
 		}


### PR DESCRIPTION
reflect.DeepEqual() does not work as expected anymore with APIV2, see #310 for details.
Using proto.Equal() instead.

fixes #310

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
