### PR TITLE
Support proto3 field presence

### DIFF
--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -156,6 +156,7 @@ func (t *twirp) Generate(in *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorR
 
 	// Showtime! Generate the response.
 	resp := new(plugin.CodeGeneratorResponse)
+	resp.SupportedFeatures = proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL))
 	for _, f := range t.genFiles {
 		respFile := t.generate(f)
 		if respFile != nil {


### PR DESCRIPTION
Protobuf recently added support for [field presence][]. In a proto file, they are denoted by the `optional` keyword, e.g.

```proto
message Foo {
  optional string bar = 1;
}
```

Support for optional fields is opt-in on a per-code-generator basis. Without adding a particular flag, you get an error:

    example.proto: is a proto3 file that contains optional fields, but code generator protoc-gen-twirp hasn't been updated to support optional fields in proto3. Please ask the owner of this code generator to support proto3 optional.

As far as I can tell, there should not be anything special we need to do to support optional fields in Twirp as we only reference message types and don't do anything with their fields.

Support was previously attempted in https://github.com/twitchtv/twirp/pull/275 but that was closed.

[field presence]: https://github.com/protocolbuffers/protobuf/blob/v3.12.0/docs/field_presence.md#application-note-field-presence

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
