### PR TITLE
twirp.ErrorCode implements twirp.Error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -239,6 +239,20 @@ const (
 	NoError ErrorCode = ""
 )
 
+// ErrorCode implements twirp.Error, as a plain error with the same code and msg string values.
+
+func (c ErrorCode) Code() ErrorCode                { return c }
+func (c ErrorCode) Msg() string                    { return string(c) }
+func (c ErrorCode) WithMeta(key, val string) Error { return NewError(c, string(c)).WithMeta(key, val) }
+func (c ErrorCode) Meta(key string) string         { return "" }
+func (c ErrorCode) MetaMap() map[string]string     { return nil }
+func (c ErrorCode) Error() string                  { return string(c) }
+
+// WithMsg returns a copy of the error but with the specified msg.
+func (c ErrorCode) WithMsg(msg string) Error {
+	return NewError(c, msg)
+}
+
 // ServerHTTPStatusFromErrorCode maps a Twirp error type into a similar HTTP
 // response status. It is used by the Twirp server handler to set the HTTP
 // response status code. Returns 0 if the ErrorCode is invalid.

--- a/errors_test.go
+++ b/errors_test.go
@@ -171,3 +171,21 @@ func TestWriteError_WithNonTwirpError(t *testing.T) {
 		return
 	}
 }
+
+func TestCodeAsError(t *testing.T) {
+	c := NotFound
+	var _ Error = c // twirp.ErrorCode implements twirp.Error
+
+	if c.Code() != NotFound {
+		t.Errorf("got wrong error code. have=%s, want=%s", c.Code(), NotFound)
+	}
+	if c.Msg() != "not_found" {
+		t.Errorf("got wrong msg. have=%s, want=%s", c.Msg(), "not_found")
+	}
+	if c.Error() != "not_found" {
+		t.Errorf("got wrong error. have=%s, want=%s", c.Error(), "not_found")
+	}
+	if c.Meta("foobar") != "" {
+		t.Errorf("expected code.Meta to be empty. have=%q", c.Meta("foobar"))
+	}
+}


### PR DESCRIPTION
## What if error codes could also be errors?

This will allow alternative error constructors to the current `twirp.NewError` constructor and similar helpers, to return simpler errors, for example:

```go
return nil, twirp.NotFound

return nil, twirp.NotFound.WithMsg("specific thing was not found")

return nil. twirp.NotFound.WithMsg("foobar").WithMeta("foo", "bar")
```

this is the equivalent of:

```go
return nil, twirp.NewError(twirp.NotFound, "not_found")

return nil, twirp.NewError(twirp.NotFound, "specific thing was not found")

return nil, twirp.NewError(twirp.NotFound, "foobar").WithMeta("foo", "bar")
```

And it will be consistent for every twirp error code.

## Example endpoint

Making `twirp.ErrorCode` to also implement a `twirp.Error` and an `error`, allows a new idiom to construct twirp errors:

```go
func (s *MyService) MyMethod(ctx context.Context, req *mysvc.MyRequest) (*mysvc.MyResponse, error) {
  if req.UserId == "" {
    return nil, twirp.InvalidArgument.WithMsg("user_id is required")
  }
  
  user, err := s.DB.LoadUser(ctx, req.UserId)
  if err != nil {
    return nil, twirp.WrapError(twirp.Internal, err)
  }

  if user == nil {
    return nil, twirp.NotFound
  }

  return &mysvc.MyResponse{}, nil
}
```

For comparison, the same code would look like this without the error code constructors:
Today, this is how returning errors looks like in most Twirp services:

```go
func (s *MyService) MyMethod(ctx context.Context, req *mysvc.MyRequest) (*mysvc.MyResponse, error) {
  if req.UserId == "" {
    return nil, twirp.NewError(twirp.InvalidArgument, "user_id is required")
  }
  
  user, err := s.DB.LoadUser(ctx, req.UserId)
  if err != nil {
    return nil, twirp.WrapError(twirp.InternalError("internal"), err)
  }

  if user == nil {
    return nil, twirp.NotFoundError("not_found")
  }

  return &mysvc.MyResponse{}, nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
