### PR TITLE
New Error Constructors: code.Error(msg) and code.Errorf(msg, a...)

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package twirp
+package twirp_test
 
 import (
 	"encoding/json"
@@ -22,10 +22,77 @@ import (
 	"testing"
 
 	pkgerrors "github.com/pkg/errors"
+	"github.com/twitchtv/twirp"
 )
 
+func TestErrorConstructors(t *testing.T) {
+	var twerr twirp.Error
+	err := errors.New("The OG error")
+
+	// code.Error
+
+	twerr = twirp.NotFound.Error("oops")
+	assertTwirpError(t, twerr, twirp.NotFound, "oops")
+
+	// code.Errorf
+
+	twerr = twirp.Aborted.Errorf("oops %d %s", 11, "times")
+	assertTwirpError(t, twerr, twirp.Aborted, "oops 11 times")
+
+	twerr = twirp.Internal.Errorf("oops: %w", err)
+	assertTwirpError(t, twerr, twirp.Internal, "oops: The OG error")
+	if !errors.Is(twerr, err) {
+		t.Errorf("expected wrap the original error")
+	}
+
+	// twirp.NewError
+
+	twerr = twirp.NewError(twirp.NotFound, "oops")
+	assertTwirpError(t, twerr, twirp.NotFound, "oops")
+
+	// twirp.NewErrorf
+
+	twerr = twirp.NewErrorf(twirp.Aborted, "oops %d %s", 11, "times")
+	assertTwirpError(t, twerr, twirp.Aborted, "oops 11 times")
+
+	twerr = twirp.NewErrorf(twirp.Internal, "oops: %w", err)
+	assertTwirpError(t, twerr, twirp.Internal, "oops: The OG error")
+	if !errors.Is(twerr, err) {
+		t.Errorf("expected wrap the original error")
+	}
+
+	// Convenience constructors
+
+	twerr = twirp.NotFoundError("oops")
+	assertTwirpError(t, twerr, twirp.NotFound, "oops")
+
+	twerr = twirp.InvalidArgumentError("my_arg", "is invalid")
+	assertTwirpError(t, twerr, twirp.InvalidArgument, "my_arg is invalid")
+	assertTwirpErrorMeta(t, twerr, "argument", "my_arg")
+
+	twerr = twirp.RequiredArgumentError("my_arg")
+	assertTwirpError(t, twerr, twirp.InvalidArgument, "my_arg is required")
+	assertTwirpErrorMeta(t, twerr, "argument", "my_arg")
+
+	twerr = twirp.InternalError("oops")
+	assertTwirpError(t, twerr, twirp.Internal, "oops")
+
+	twerr = twirp.InternalErrorf("oops: %w", err)
+	assertTwirpError(t, twerr, twirp.Internal, "oops: The OG error")
+	if !errors.Is(twerr, err) {
+		t.Errorf("expected wrap the original error")
+	}
+
+	twerr = twirp.InternalErrorWith(err)
+	assertTwirpError(t, twerr, twirp.Internal, "The OG error")
+	if !errors.Is(twerr, err) {
+		t.Errorf("expected wrap the original error")
+	}
+	assertTwirpErrorMeta(t, twerr, "cause", "*errors.errorString")
+}
+
 func TestWithMetaRaces(t *testing.T) {
-	err := NewError(Internal, "msg")
+	err := twirp.NewError(twirp.Internal, "msg")
 	err = err.WithMeta("k1", "v1")
 
 	var wg sync.WaitGroup
@@ -46,7 +113,7 @@ func TestWithMetaRaces(t *testing.T) {
 
 func TestPkgErrorCause(t *testing.T) {
 	rootCause := pkgerrors.New("this is only a test")
-	twerr := InternalErrorWith(rootCause)
+	twerr := twirp.InternalErrorWith(rootCause)
 	cause := pkgerrors.Cause(twerr)
 	if cause != rootCause {
 		t.Errorf("got wrong cause for err. have=%q, want=%q", cause, rootCause)
@@ -55,8 +122,8 @@ func TestPkgErrorCause(t *testing.T) {
 
 func TestWrapError(t *testing.T) {
 	rootCause := errors.New("cause")
-	twerr := NewError(NotFound, "it ain't there")
-	err := WrapError(twerr, rootCause)
+	twerr := twirp.NewError(twirp.NotFound, "it ain't there")
+	err := twirp.WrapError(twerr, rootCause)
 	cause := pkgerrors.Cause(err)
 	if cause != rootCause {
 		t.Errorf("got wrong cause. got=%q, want=%q", cause, rootCause)
@@ -76,7 +143,7 @@ func (e myError) Error() string {
 func TestInternalErrorWith_Unwrap(t *testing.T) {
 	myErr := myError("myError")
 	wrErr := fmt.Errorf("wrapped: %w", myErr) // double wrap
-	twerr := InternalErrorWith(wrErr)
+	twerr := twirp.InternalErrorWith(wrErr)
 
 	if !errors.Is(twerr, myErr) {
 		t.Errorf("expected errors.Is to match the error wrapped by twirp.InternalErrorWith")
@@ -99,16 +166,22 @@ func (errorResponeWriter) Write([]byte) (int, error) {
 	return 0, errors.New("this is only a test")
 }
 
+type twerrJSON struct {
+	Code string            `json:"code"`
+	Msg  string            `json:"msg"`
+	Meta map[string]string `json:"meta,omitempty"`
+}
+
 func TestWriteError(t *testing.T) {
 	resp := httptest.NewRecorder()
-	twerr := NewError(Internal, "test middleware error")
-	err := WriteError(resp, twerr)
+	twerr := twirp.NewError(twirp.Internal, "test middleware error")
+	err := twirp.WriteError(resp, twerr)
 	if err != nil {
 		t.Errorf("got an error from WriteError when not expecting one: %s", err)
 		return
 	}
 
-	twerrCode := ServerHTTPStatusFromErrorCode(twerr.Code())
+	twerrCode := twirp.ServerHTTPStatusFromErrorCode(twerr.Code())
 	if resp.Code != twerrCode {
 		t.Errorf("got wrong status. have=%d, want=%d", resp.Code, twerrCode)
 		return
@@ -121,7 +194,7 @@ func TestWriteError(t *testing.T) {
 		return
 	}
 
-	if ErrorCode(gotTwerrJSON.Code) != twerr.Code() {
+	if twirp.ErrorCode(gotTwerrJSON.Code) != twerr.Code() {
 		t.Errorf("got wrong error code. have=%s, want=%s", gotTwerrJSON.Code, twerr.Code())
 		return
 	}
@@ -134,7 +207,7 @@ func TestWriteError(t *testing.T) {
 	errResp := &errorResponeWriter{ResponseRecorder: resp}
 
 	// Writing again should error out as headers are being rewritten
-	err = WriteError(errResp, twerr)
+	err = twirp.WriteError(errResp, twerr)
 	if err == nil {
 		t.Errorf("did not get error on write. have=nil, want=some error")
 	}
@@ -143,7 +216,7 @@ func TestWriteError(t *testing.T) {
 func TestWriteError_WithNonTwirpError(t *testing.T) {
 	resp := httptest.NewRecorder()
 	nonTwerr := errors.New("not a twirp error")
-	err := WriteError(resp, nonTwerr)
+	err := twirp.WriteError(resp, nonTwerr)
 	if err != nil {
 		t.Errorf("got an error from WriteError when not expecting one: %s", err)
 		return
@@ -161,13 +234,32 @@ func TestWriteError_WithNonTwirpError(t *testing.T) {
 		return
 	}
 
-	if ErrorCode(gotTwerrJSON.Code) != Internal {
-		t.Errorf("got wrong error code. have=%s, want=%s", gotTwerrJSON.Code, Internal)
+	if twirp.ErrorCode(gotTwerrJSON.Code) != twirp.Internal {
+		t.Errorf("got wrong error code. have=%s, want=%s", gotTwerrJSON.Code, twirp.Internal)
 		return
 	}
 
 	if gotTwerrJSON.Msg != ""+nonTwerr.Error() {
 		t.Errorf("got wrong error message. have=%s, want=%s", gotTwerrJSON.Msg, nonTwerr.Error())
 		return
+	}
+}
+
+// Test helpers
+
+func assertTwirpError(t *testing.T, twerr twirp.Error, code twirp.ErrorCode, msg string) {
+	t.Helper()
+	if twerr.Code() != code {
+		t.Errorf("wrong code. have=%q, want=%q", twerr.Code(), code)
+	}
+	if twerr.Msg() != msg {
+		t.Errorf("wrong msg. have=%q, want=%q", twerr.Msg(), msg)
+	}
+}
+
+func assertTwirpErrorMeta(t *testing.T, twerr twirp.Error, key string, value string) {
+	t.Helper()
+	if twerr.Meta(key) != value {
+		t.Errorf("wrong meta. have=%q, want=%q", twerr.Meta(key), value)
 	}
 }


### PR DESCRIPTION
## Build Twirp Errors from  the Code

The standard error constructor `twirp.NewError(twirp.ErrorCode, msg)` stutters and is a bit verbose.

Since the code constants are already defined at the top level of the twirp package, they can be used to build all the error types. It is easier to read and consistent for all codes:

```go
twirp.Internal.Error("oops")
twirp.NotFound.Error("resource not found")
twirp.PermissionDenied.Error("thou shall no pass")
```

## Errorf to format and wrap other errors

The signature `Errorf` is a well-known idiom in Go and could be used to format errors exactly as it would be expected:

```go
twirp.Internal.Errorf("oops: %w", err) // wrapping another error
twirp.NotFound.Errorf("resource with id: %d", id) // interpolation
twirp.PermissionDenied.Errorf("user %q with id %d not allowed: %w", login, id, err) // all of the above
```

Wrapping errors with "%w" is specially useful to prefix internal errors. APIs that use middleware to report errors often need to unwrap those errors to know the originals, but having a prefix in front of them is useful for debugging. Example:

```go
record, err := s.DB.LoadRecord(ctx, resourceID)
if err != nil {
    return nil, twirp.Internal.Errorf("failed to load resource %q: %w", resourceID, err)
}
```

## Existing constructors enhanced

Existing constructors still apply and are consistent with the new ones. An `Errorf` version of those constructors was also added for consistency. 

```go
twirp.InternalError("oops")
twirp.InternalErrorf("oops: %w", err)
twirp.InternalErrorWith(err)

twirp.NotFoundError("resource not found")
twirp.NewError(twirp.NotFound, "resource not found")

twirp.InvalidArgumentError("arg", "is invalid")
twirp.InvalidArgument.Error("arg is invalid").WithMeta("argument", "arg")
twirp.NewError(twirp.InvalidArgument, "arg is invalid").WithMeta("argument", "arg")
```

## Usage Example

Let's see how the new constructors look like on an example endpoint implementation:

```go
func (s *MyService) MyMethod(ctx context.Context, req *mysvc.MyRequest) (*mysvc.MyResponse, error) {
  if req.UserId == "" {
    return nil, twirp.InvalidArgument.Error("user_id is required")
  }
  
  user, err := s.DB.LoadUser(ctx, req.UserId)
  if err != nil {
    return nil, twirp.Internal.Errorf("failed to load user %q: %w", req.UserId, err)
  }
  if user == nil {
    return nil, twirp.NotFound.Errorf("user %q not found", req.UserId)
  }

  if !auth.Check(ctx, req.UserId) {
    return nil, twirp.PermissionDenied.Error("authorization check")
  }

  return &mysvc.MyResponse{UserName: user.Name}, nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
