### PR TITLE
Docs: Fix installation commands

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -54,8 +54,8 @@ export PATH=$GOBIN:$PATH
 Install generators:
 
 ```sh
-go install github.com/twitchtv/twirp/protoc-gen-twirp
-go install google.golang.org/protobuf/cmd/protoc-gen-go
+go install github.com/twitchtv/twirp/protoc-gen-twirp@latest
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 ```
 
 


### PR DESCRIPTION
The installation guide in the docs uses a slightly outdated `go install` command as this now requires a version to install (e.g. `@latest`) as the suffix.

This is a small change to add this `latest` version info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
