### PR TITLE
Fix generation of the best practices page

### DIFF
--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -1,7 +1,7 @@
 ---
-id: 'best_practices'
-title: 'Best Practices'
-sidebar_label: 'Best Practices'
+id: "best_practices"
+title: "Best Practices"
+sidebar_label: "Best Practices"
 ---
 
 Twirp simplifies service design when compared with a REST endpoint: method


### PR DESCRIPTION
#348 

This pull request fixes the problem when generating the `best practices` page in the documentation. For this, just change the quotes in the page's markdown metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
