### PR TITLE
add-meta-cause-to-wrapped-error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -92,6 +92,7 @@ func (code ErrorCode) Errorf(msgFmt string, a ...interface{}) Error {
 // The wrapped error can be extracted later with (github.com/pkg/errors).Unwrap
 // or errors.Is from the standard errors package on Go 1.13+.
 func WrapError(twerr Error, err error) Error {
+	twerr = twerr.WithMeta("cause", err.Error())
 	return &wrappedErr{
 		wrapper: twerr,
 		cause:   err,


### PR DESCRIPTION
*Description of changes:*
Adding `cause` meta when wrapping twirp error. It helps when returning the error response when it fails to protojson.unmarshal, it adds the specific error. For example, current error response:
```
{
    "code": "malformed",
    "msg": "the json request could not be decoded"
}
```

With this change:
```
{
    "code": "malformed",
    "msg": "the json request could not be decoded",
    "meta": {
        "cause": "proto: (line 22:17): invalid value for enum type: \"XYZ\""
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
