### PR TITLE
Replace references to Error type with Error code

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -55,14 +55,14 @@ One exception to this is that names match the proto names, this is considered mo
 
 Errors returned by Twirp servers use non-200 HTTP status codes and always have
 JSON-encoded bodies (even if the request was Protobuf-encoded). The body JSON
-has three fields `{type, msg, meta}`. For example:
+has three fields `{code, msg, meta}`. For example:
 
 ```
 POST /twirp/twirp.example.haberdasher.Haberdasher/INVALIDROUTE
 
 404 Not Found
 {
-    "type": "bad_route",
+    "code": "bad_route",
     "msg": "no handler for path /twirp/twirp.example.haberdasher.Haberdasher/INVALIDROUTE",
     "meta": {"twirp_invalid_route": "POST /twirp/twirp.example.haberdasher.Haberdasher/INVALIDROUTE"}
 }

--- a/errors.go
+++ b/errors.go
@@ -69,7 +69,7 @@ type Error interface {
 	// MetaMap returns the complete key-value metadata map stored on the error.
 	MetaMap() map[string]string
 
-	// Error returns a string of the form "twirp error <Type>: <Msg>"
+	// Error returns a string of the form "twirp error <Code>: <Msg>"
 	Error() string
 }
 


### PR DESCRIPTION
Just noticed looking at the docs that according to the routing section errors have a "type" field, but everywhere else this field is called "code" (I guess it was "type" in a previous version).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
