### PR TITLE
Update docs for Twirp Errors

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -4,29 +4,40 @@ title: "Errors"
 sidebar_label: "Errors"
 ---
 
-Twirp errors are JSON responses with `code`, `msg` and (optional) `meta` keys.
+## Overview
 
-Example of `internal` error:
+Service endpoint returns a Twirp error:
 
-```json
-{
-  "code": "internal",
-  "msg": "something went wrong",
+```go
+func (s *Server) Foo(ctx context.Context, req *pb.FooRequest) (*pb.FooResp, error) {
+    return nil, twirp.PermissionDenied.Error("this door is closed")
 }
 ```
 
-Example of `not_found` error with metadata:
+Twirp serializes the response as a JSON with `code` and `msg` keys:
 
 ```json
+// HTTP status code: 403
 {
-  "code": "not_found",
-  "msg": "user not found",
-  "meta": {
-    "user_id": "123",
-    "retry": "no",
-  },
+  "code": "permission_denied",
+  "msg": "this door is closed"
 }
 ```
+
+The auto-generated client de-serializes and returns the same Twirp error:
+
+```go
+resp, err := client.Foo(ctx, req)
+if err != nil {
+    err.Error() //=> "twirp error permission_deined: this door is closed"
+
+    twerr := err.(twirp.Error)
+    twerr.Code() // => twirp.PermissionDenied
+    twerr.Msg() //=> "this door is closed"
+}
+```
+
+## Error Codes
 
 Valid Twirp Error Codes:
 
@@ -36,23 +47,27 @@ Valid Twirp Error Codes:
  * `unauthenticated` (401)
  * `permission_denied` (403)
  * `already_exists` (409)
- * ... see all codes on the [Errors Spec](spec_v7.md#error-codes).
+ * ... see all available codes on the [Errors Spec](spec_v7.md#error-codes).
 
-Twirp services map each error code to a equivalent HTTP status to make it easy to check for errors on middleware.
+Twirp services map each error code to a equivalent HTTP status to make it easy to check for errors on middleware (See [twirp.ServerHTTPStatusFromErrorCode](https://pkg.go.dev/github.com/twitchtv/twirp#ServerHTTPStatusFromErrorCode)).
 
-In Go, Twirp errors satisfy the [twirp.Error](https://pkg.go.dev/github.com/twitchtv/twirp#Error) interface. The `twirp` package provides error constructors from the codes (e.g. `twirp.Internal.Error("something went wrong")`) and a generic constructor [twirp.NewError](https://pkg.go.dev/github.com/twitchtv/twirp#NewError). Check the [errors.go](https://github.com/twitchtv/twirp/blob/main/errors.go) file for more examples!
+In Go, Twirp errors satisfy the [twirp.Error](https://pkg.go.dev/github.com/twitchtv/twirp#Error) interface. The `twirp` package provides error constructors from the codes (e.g. `twirp.Internal.Error("something went wrong")`) (added on v8.1.1), and a generic constructor [twirp.NewError](https://pkg.go.dev/github.com/twitchtv/twirp#NewError). Check the [errors.go file for examples](https://github.com/twitchtv/twirp/blob/main/errors.go).
 
 
-### Returning Twirp errors from Go Services
+## Server Side: Returning Error Responses
 
-Example service implementation returning Twirp errors:
+A Twirp endpoint may return an error. If the error value implements the [twirp.Error](https://pkg.go.dev/github.com/twitchtv/twirp#Error) interface, it will be serialized and received by the client with the exact same `code`, `msg` and `meta` properties.
+
+Example of an endpoint returning Twirp errors:
 
 ```go
 func (s *Server) FindUser(ctx context.Context, req *pb.FindUserRequest) (*pb.FindUserResp, error) {
+    // Validation errors
     if req.UserId == "" {
-        return nil, twirp.InvalidArgument.Error("user_id is required").WithMeta("arg", "user_id")
+        return nil, twirp.InvalidArgument.Error("user_id is required")
     }
 
+    // Perform some operation
     user, err := s.DB.FindByID(ctx, req.UserID)
     if errors.Is(err, DB_NOT_FOUND) {
         return nil, twirp.NotFound.Error("user not found")
@@ -61,26 +76,56 @@ func (s *Server) FindUser(ctx context.Context, req *pb.FindUserRequest) (*pb.Fin
         return nil, twirp.Internal.Errorf("DB error: %w", err)
     }
 
+    // Success
     return &pb.FindUserResp{
         Login: user.Login,
-        // ...
     }, nil
 }
 ```
 
-Error values that implement the [twirp.Error](https://pkg.go.dev/github.com/twitchtv/twirp#Error) interface are sent through the wire and returned with the same `code`, `msg` and `meta` in the client.
-
-Regular non-twirp errors are automatically wrapped as internal errors (using [twirp.InternalErrorWith(err)](https://pkg.go.dev/github.com/twitchtv/twirp#InternalErrorWith)). The original error can be unwrapped and accessed on service hooks and middleware (e.g. using `errors.Unwrap`). But the original error is NOT serialized through the network; clients cannot access the original error, and will instead receive a `twirp.Error` with code `internal`.
-
-Example returning a non-twirp error:
+If the error is a vanila (non-twirp) error, it will be automatically wrapped as an internal error with [twirp.InternalErrorWith(err)](https://pkg.go.dev/github.com/twitchtv/twirp#InternalErrorWith)). The original error can be unwrapped and accessed on service hooks and middleware (e.g. using [errors.Unwrap](https://pkg.go.dev/errors#Unwrap) or [errors.As](https://pkg.go.dev/errors#As)), but not on the client; the original error is not serialized through the network, and the client will instead receive an `internal` error with the same error message.
 
 ```go
 func (s *Server) FindUser(ctx context.Context, req *pb.FindUserRequest) (*pb.FindUserResp, error) {
-    return nil, errors.New("will be serialized as twirp.Internal")
+    err := errors.New("vanila error")
+
+    return nil, err
 }
 ```
 
-### Handling errors on Go Clients
+This code is equivalent to explicitly using the wrapper:
+
+```go
+func (s *Server) FindUser(ctx context.Context, req *pb.FindUserRequest) (*pb.FindUserResp, error) {
+    err := errors.New("vanila error")
+
+    return nil, twirp.InternalErrorWith(err)
+}
+```
+
+Which is also equivalent to building an internal error wrapping the original like this:
+
+```go
+func (s *Server) FindUser(ctx context.Context, req *pb.FindUserRequest) (*pb.FindUserResp, error) {
+    err := errors.New("vanila error")
+
+	return twirp.Internal.Errorf("%w", err.Error()).
+        WithMeta("cause", fmt.Sprintf("%T", err))
+}
+```
+
+### Error responses from outside Twirp endpoints
+
+Twirp services can be [muxed with other HTTP services](mux.md). For consistent responses and error codes _outside_ Twirp servers, such as HTTP middleware, you can call [twirp.WriteError](https://pkg.go.dev/github.com/twitchtv/twirp#WriteError).
+
+```go
+twerr := twirp.Unauthenticated.Error("invalid token")
+
+twirp.WriteError(respWriter, twerr)
+```
+
+
+## Client Side: Handling Error Responses
 
 Twirp clients return errors that can always be cast to the `twirp.Error` interface. Unpack the error type to access the `Code()`, `Msg()` and `Meta(key)` properties:
 
@@ -90,10 +135,9 @@ if err != nil {
     if twerr, ok := err.(twirp.Error); ok {
         if twerr.Code() == twirp.NotFound {
             fmt.Println("not found")
-        } else {
-            fmt.Printf("Twirp error %s: %q", twerr.Code(), twerr.Msg())
         }
     }
+    fmt.Printf("internal: %s", err)
 }
 ```
 
@@ -105,13 +149,13 @@ var twerr twirp.Error
 if errors.As(err, &twerr) {
     if twerr.Code() == twirp.NotFound {
         fmt.Println("not found")
-    } else {
-        fmt.Printf("Twirp error %s: %q", twerr.Code(), twerr.Msg())
     }
+} else if err != nil {
+    fmt.Printf("internal: %s", err)
 }
 ```
 
-Transport-level errors (like connection errors) are returned as internal errors by default. If desired, the original client-side network error can be unwrapped:
+Transport-level errors (e.g. connection issues) are returned as internal errors. If desired, the original client-side network error can be unwrapped:
 
 ```go
 resp, err := client.MakeHat(ctx, req)
@@ -125,9 +169,6 @@ if errors.As(err, &twerr) {
 }
 ```
 
-If the server error was wrapping an original service error, that can not be accessed in the client; only the twirp error properties `code`, `msg` and `meta` are serialized over the network.
-
-
 ### HTTP Errors from Intermediary Proxies
 
 Twirp Clients may receive HTTP responses with non-200 status
@@ -135,12 +176,11 @@ from different sources like proxies or load balancers. For example,
 a "503 Service Temporarily Unavailable" body, which cannot be
 deserialized into a Twirp error.
 
-In those cases, generated Go clients will return `twirp.Error` with a code
-depending on the HTTP status of the invalid response:
+In those cases, generated Go clients will try to best-guess the equivalent Twirp error depending on the HTTP status of the invalid response:
 
 | HTTP status code         |  Twirp Error Code
 | ------------------------ | ------------------
-| 3xx (redirects)          | Internalreturn nil, fmt.Errorf("this non-twirp error will
+| 3xx (redirects)          | Internal
 | 400 Bad Request          | Internal
 | 401 Unauthorized         | Unauthenticated
 | 403 Forbidden            | PermissionDenied
@@ -158,9 +198,12 @@ Additional metadata is added to make it easy to identify intermediary errors:
 * `"body": string` (original non-Twirp error response as string).
 * `"location": url-string` (only on 3xx responses, matching the `Location` header).
 
-### Metadata
 
-Arbitrary string metadata can be added to any error. For example, a service may return this:
+## Metadata
+
+In addition to `code` and `msg`, Twirp errors can optionally include arbitrary string metadata in the `meta` field.
+
+For example, some server code could return an error like this:
 
 ```go
 if unavailable {
@@ -170,7 +213,21 @@ if unavailable {
 }
 ```
 
-Metadata is available on the client as expected:
+Twirp serializes the response as a JSON with the additional `meta` field:
+
+```json
+// HTTP status code: 503
+{
+  "code": "unavailable",
+  "msg": "taking a nap ...",
+  "meta": {
+    "retryable": "true",
+    "retry_after": "15s"
+  }
+}
+```
+
+Metadata is available on the client using the `.Meta(key)` accessor:
 
 ```go
 if twerr.Code() == twirp.Unavailable {
@@ -180,16 +237,4 @@ if twerr.Code() == twirp.Unavailable {
 }
 ```
 
-Error metadata can only have string values. This is to simplify error parsing by clients. If your service requires errors with complex metadata, you should consider adding client wrappers on top of the auto-generated clients, or add specific business-logic errors as a speficic error field on the Protobuf messages.
-
-
-### Writing HTTP Errors outside Twirp services
-
-Twirp services can be [muxed with other HTTP services](mux.md). For consistent responses and error codes _outside_ Twirp servers, such as HTTP middleware, you can call [twirp.WriteError](https://pkg.go.dev/github.com/twitchtv/twirp#WriteError).
-
-```go
-twerr := twirp.Unauthenticated.Error("invalid token")
-twirp.WriteError(respWriter, twerr)
-```
-
-As with returned service errors, the error is expected to satisfy the `twirp.Error` interface, otherwise it is wrapped as a `twirp.InternalError`.
+Error metadata can only have string values. This is to simplify error parsing by client implementations in multiple platforms. If your service requires errors with complex shapes, consider adding client wrappers on top of the auto-generated clients, or include specific business-logic errors on the Protobuf messages (as part of success responses).

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -5,9 +5,9 @@
     "previous": "Previous",
     "tagline": "Simple RPC framework powered by protobuf",
     "docs": {
-      "'best_practices'": {
-        "title": "'Best Practices'",
-        "sidebar_label": "'Best Practices'"
+      "best_practices": {
+        "title": "Best Practices",
+        "sidebar_label": "Best Practices"
       },
       "command_line": {
         "title": "Generator Flags for the Protoc Compiler",


### PR DESCRIPTION
Update docs for Twirp Errors:

 * Organize for better readability: Overview; Error codes; Server side; Client side; Metadata.
 * Update examples using new error constructors and idioms.
 * Show common error codes first, and include a link to see all other codes in the spec.
 * Improve links to source code on relevant examples.
 * Explain how vanilla (non-twirp) errors are wrapped as internal errors with more detail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
