### PR TITLE
fix issue #371

### DIFF
--- a/protoc-gen-twirp/generator.go
+++ b/protoc-gen-twirp/generator.go
@@ -819,7 +819,7 @@ func (t *twirp) generateUtils() {
 
 	t.P(`// doJSONRequest makes a JSON request to the remote Twirp service.`)
 	t.P(`func doJSONRequest(ctx `, t.pkgs["context"], `.Context, client HTTPClient, hooks *`, t.pkgs["twirp"], `.ClientHooks, url string, in, out `, t.pkgs["proto"], `.Message) (_ `, t.pkgs["context"], `.Context, err error) {`)
-	t.P(`  marshaler := &`, t.pkgs["protojson"], `.MarshalOptions{UseProtoNames: true}`)
+	t.P(`  marshaler := &`, t.pkgs["protojson"], `.MarshalOptions{UseProtoNames: !s.jsonCamelCase, EmitUnpopulated: !s.jsonSkipDefaults}`)
 	t.P(`  reqBytes, err := marshaler.Marshal(in)`)
 	t.P(`  if err != nil {`)
 	t.P(`    return ctx, wrapInternal(err, "failed to marshal json request")`)


### PR DESCRIPTION
*Issue #371:*

*Description of changes:*
generator.go in func doJSONRequest was changed from 

```
	t.P(`  marshaler := &`, t.pkgs["protojson"], `.MarshalOptions{UseProtoNames: true}`)
``` 
to 
```
	t.P(`  marshaler := &`, t.pkgs["protojson"], `.MarshalOptions{UseProtoNames: !s.jsonCamelCase, EmitUnpopulated: !s.jsonSkipDefaults}`)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
