### PR TITLE
Remove protoc-gen-twirp_typescript from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Here is a list of some third-party implementations in other languages.
 | **JavaScript** |    ✓    |         | [github.com/Xe/twirp-codegens/cmd/protoc-gen-twirp_jsbrowser](https://github.com/Xe/twirp-codegens)
 | **JavaScript** |    ✓    |    ✓    | [github.com/tatethurston/TwirpScript](https://github.com/tatethurston/TwirpScript)
 | **Typescript** |    ✓    |    ✓    | [github.com/hopin-team/twirp-ts](https://github.com/hopin-team/twirp-ts)
-| **Typescript** |    ✓    |         | [github.com/larrymyers/protoc-gen-twirp_typescript](https://github.com/larrymyers/protoc-gen-twirp_typescript)
 | **Typescript** |    ✓    |    ✓    | [github.com/tatethurston/TwirpScript](https://github.com/tatethurston/TwirpScript)
 | **Typescript** |    ✓    |    ✓    | [github.com/timostamm/protobuf-ts](https://github.com/timostamm/protobuf-ts)
 | **Ruby**       |    ✓    |    ✓    | [github.com/twitchtv/twirp-ruby](https://github.com/twitchtv/twirp-ruby)


### PR DESCRIPTION
*Description of changes:*

I no longer maintain this library, and have archived the repo. It should no longer be listed as a Typescript integration for Twirp.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
