### PR TITLE
Fix example protoc arguments

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -60,7 +60,10 @@ To generate code run the `protoc` compiler pointed at your service's `.proto`
 files:
 
 ```sh
-$ protoc --twirp_out=. --go_out=paths=. rpc/haberdasher/service.proto
+$ protoc --go_out=. --twirp_out=. \
+   --go_opt=paths=source_relative \
+   --twirp_opt=paths=source_relative \
+   rpc/haberdasher/service.proto
 ```
 
 See [Generator Command Line Arguments](command_line.md) for details about running the generator.


### PR DESCRIPTION
*Description of changes:*

Running the command in the example documentation results in the error `paths=./: No such file or directory`. This changes the arguments to be the same as other commands elsewhere in the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
