### PR TITLE
Fix the parameter error `--go_out=paths=.` in the example

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -60,7 +60,7 @@ To generate code run the `protoc` compiler pointed at your service's `.proto`
 files:
 
 ```sh
-$ protoc --twirp_out=. --go_out=paths=. rpc/haberdasher/service.proto
+$ protoc --twirp_out=. --go_out=. rpc/haberdasher/service.proto
 ```
 
 See [Generator Command Line Arguments](command_line.md) for details about running the generator.


### PR DESCRIPTION
It is straightforward, and I tested the parameter with `--go_out=.`. The  previous parameter `go_out=path=.` doesn't work.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
