### PR TITLE
add .well-known to static directory to resolve automated lookalike warning

### DIFF
--- a/website/static/.well-known/assetlinks.json
+++ b/website/static/.well-known/assetlinks.json
@@ -1,0 +1,7 @@
+[{
+    "relation": ["lookalikes/allowlist"],
+    "target": { "namespace": "web", "site": "https://twitchtv.github.io" }
+},{
+    "relation": ["looksalike/allowlist"],
+    "target": { "namespace": "web", "site": "https://twitch.tv" }
+}]

--- a/website/static/.well-known/assetlinks.json
+++ b/website/static/.well-known/assetlinks.json
@@ -1,7 +1,7 @@
 [{
     "relation": ["lookalikes/allowlist"],
-    "target": { "namespace": "web", "site": "https://twitchtv.github.io" }
+    "target" : { "namespace": "web", "site": "https://twitchtv.github.io" }
 },{
-    "relation": ["looksalike/allowlist"],
-    "target": { "namespace": "web", "site": "https://twitch.tv" }
+    "relation": ["lookalikes/allowlist"],
+    "target" : { "namespace": "web", "site": "https://twitch.tv" }
 }]


### PR DESCRIPTION
*Issue:* #390 

*Description of changes:*

Following google's instructions here: https://chromium.googlesource.com/chromium/src/+/master/docs/security/lookalikes/lookalike-domains.md#Removing-Lookalike-Warnings-from-a-site

I know it says not to use subdomains, but I figure because the error itself only presents on the specific subdomain, that maybe we can get away with only specifying the subdomain. We can update this later to github.io if needed.

The same change needs to be made against twitch.tv, which I'll work to have done internally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
